### PR TITLE
Add Rust checks to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,15 @@
 # Copyright (C) 2022 Nitrokey GmbH
 # SPDX-License-Identifier: CC0-1.0
 
-.PHONY: lint
-lint:
+.PHONY: check
+check:
+	cargo check --all-features --all-targets
+	cargo check --no-default-features
+	cargo clippy --all-features --all-targets -- --deny warnings
+	cargo fmt -- --check
 	reuse lint
+
+.PHONY: fix
+fix:
+	cargo fix --all-features
+	cargo fmt


### PR DESCRIPTION
This patch adds calls to the compiler, clippy and cargo-fmt to the
Makefile as a quick start and as a preparation for the CI.