### PR TITLE
Add integration tests using vsmartcard and gpg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ vpicc = { git = "ssh://git@github.com/Nitrokey/vpicc-rs.git", optional = true }
 [dev-dependencies]
 env_logger = "0.9"
 openpgp-card = "0.2.7"
+stoppable_thread = "0.2.1"
+test-log = "0.2.10"
 
 [features]
 std = []

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ fix:
 
 .PHONY: test
 test:
-	cargo test --features backend-software
+	RUST_LOG=info cargo test --all-features
 
 .PHONY: ci
 ci: check test

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -4,10 +4,19 @@
 FROM rust:latest
 
 RUN apt update
-RUN apt install --yes libclang-dev llvm python3-pip
+RUN apt install --yes gnupg scdaemon libclang-dev llvm python3-pip vsmartcard-vpcd
 
 RUN python3 -m pip install reuse
 
 RUN rustup component add clippy rustfmt
 
+# initialize cargo cache
+RUN cargo search
+
+RUN mkdir -p ~/.gnupg
+RUN echo "disable-ccid" > ~/.gnupg/scdaemon.conf
+
 WORKDIR /app
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]

--- a/ci/entrypoint.sh
+++ b/ci/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Copyright (C) 2022 Nitrokey GmbH
+# SPDX-License-Identifier: CC0-1.0
+
+set -e
+pcscd
+exec "$@"

--- a/tests/virtual.rs
+++ b/tests/virtual.rs
@@ -1,0 +1,54 @@
+// Copyright (C) 2022 Nitrokey GmbH
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#![cfg(all(feature = "backend-software", feature = "virtual"))]
+
+use std::process::Command;
+
+use stoppable_thread::spawn;
+use test_log::test;
+
+fn with_vsc<F: Fn() -> R, R>(f: F) -> R {
+    let backend = opcard::backend::SoftwareBackend::default();
+    let card = opcard::Card::new(backend, opcard::Options::default());
+    let virtual_card = opcard::VirtualCard::new(card);
+    let mut vpicc = vpicc::SmartCard::with_card(virtual_card);
+
+    let handle = spawn(move |stopped| {
+        let mut connection = vpicc.connect();
+        let mut cont = true;
+        while !stopped.get() && cont {
+            cont = connection.poll();
+        }
+        connection.shutdown();
+    });
+
+    // TODO: detect first communication instead of hardcoded sleep
+    std::thread::sleep(std::time::Duration::from_millis(250));
+
+    let result = f();
+
+    handle.stop().join().expect("failed to join vpicc thread");
+    result
+}
+
+#[test]
+#[ignore]
+fn gpg_card_status() {
+    with_vsc(|| {
+        let output = Command::new("gpg")
+            .arg("--card-status")
+            .output()
+            .expect("failed to run gpg --card-status");
+
+        println!("=== stdout ===");
+        println!("{}", String::from_utf8_lossy(&output.stdout));
+
+        println!();
+
+        println!("=== stderr ===");
+        println!("{}", String::from_utf8_lossy(&output.stderr));
+
+        assert!(output.status.success(), "{}", output.status);
+    })
+}


### PR DESCRIPTION
This patch adds a first test case that uses vsmartcard and gpg to
perform integration tests, namely running gpg --card-status.  (Note that
it currently still fails and is therefore ignored, but this should
change soon.)