### PR TITLE
Upgrade to vpicc 0.1.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,6 @@ build:
     - docker
   stage: build
   script:
-    - sed --in-place "s#ssh://git@github.com/Nitrokey/vpicc-rs.git#https://${GITHUB_TOKEN}@github.com/Nitrokey/vpicc-rs.git#" Cargo.toml
     - make ci
   after_script:
     - wget $icon_server/checkmark/$CI_COMMIT_REF_NAME/$CI_COMMIT_SHA/$CI_JOB_NAME/$CI_JOB_STATUS/${CI_JOB_URL#*/*/*/}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ log = "0.4"
 # optional dependencies
 apdu-dispatch = { version = "0.1", optional = true }
 trussed = { version = "0.1.0", optional = true }
-vpicc = { git = "ssh://git@github.com/Nitrokey/vpicc-rs.git", optional = true }
+vpicc = { version = "0.1.0", optional = true }
 
 [dev-dependencies]
 env_logger = "0.9"

--- a/examples/virtual.rs
+++ b/examples/virtual.rs
@@ -30,7 +30,9 @@ fn main() {
 
     let backend = opcard::backend::SoftwareBackend::new("/tmp/opcard");
     let card = opcard::Card::new(backend, opcard::Options::default());
-    let virtual_card = opcard::VirtualCard::new(card);
-    let mut vpicc = vpicc::SmartCard::with_card(virtual_card);
-    vpicc.run();
+    let mut virtual_card = opcard::VirtualCard::new(card);
+    let vpicc = vpicc::connect().expect("failed to connect to vpicc");
+    vpicc
+        .run(&mut virtual_card)
+        .expect("failed to run virtual smartcard");
 }


### PR DESCRIPTION
We have now released vpicc 0.1.0 so we no longer need to use the private
Git repository.