### PR TITLE
Run ignored tests in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ fix:
 .PHONY: test
 test:
 	RUST_LOG=info cargo test --all-features
+	RUST_LOG=info cargo test --all-features -- --ignored || true
 
 .PHONY: ci
 ci: check test


### PR DESCRIPTION
With this patch, we runt the ignored tests in the CI but don’t fail the
run if one of them fails.  This makes it possible to track the behavior
of the ignored tests over time.