### PR TITLE
Test docs in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ check:
 	cargo check --no-default-features
 	cargo clippy --all-features --all-targets -- --deny warnings
 	cargo fmt -- --check
+	RUSTDOCFLAGS='-Dwarnings' cargo doc --all-features --package opcard
 	reuse lint
 
 .PHONY: fix


### PR DESCRIPTION
Running `RUSTDOCFLAGS='-Dwarnings' cargo doc --all-features` in CI will avoid missing bad intra-doc links