### PR TITLE
Fix no_std cfg_attr

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@
 //! - If the `virtual` feature is enabled, [`VirtualCard`] can be used to emulate a smart card
 //!   using [`vsmartcard`](https://frankmorgner.github.io/vsmartcard/) and `vpicc-rs`.
 
-#![cfg_attr(no_std, not(feature = "std"))]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![warn(
     missing_copy_implementations,
     missing_debug_implementations,


### PR DESCRIPTION
The cfg_attr arguments were in the wrong order
Putting them in the right order revealed a use of std in the aid method,
which was changed. A test is added to make sure the new aid function is
correct and doesn't panic