### PR TITLE
Add assertion for gpg --card-status test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ vpicc = { version = "0.1.0", optional = true }
 [dev-dependencies]
 env_logger = "0.9"
 openpgp-card = "0.2.7"
+regex = "1.6.0"
 stoppable_thread = "0.2.1"
 test-log = "0.2.10"
 trussed = { version = "0.1.0", features = ["virt"] }


### PR DESCRIPTION
This patch adds an assertion for the output of gpg --card-status to make
sure it interprets the card response as we expect it to.