### PR TITLE
Add nettle to the pipeline image

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -4,7 +4,7 @@
 FROM rust:latest
 
 RUN apt update
-RUN apt install --yes gnupg scdaemon libclang-dev llvm python3-pip vsmartcard-vpcd
+RUN apt install --yes gnupg scdaemon libclang-dev llvm python3-pip vsmartcard-vpcd pkg-config nettle-dev
 
 RUN python3 -m pip install reuse
 


### PR DESCRIPTION
This is required for building openpgp-card-sequoia for testing https://github.com/Nitrokey/opcard-rs/pull/31