### PR TITLE
command/pso: Change order for sign_verified reset

### DIFF
--- a/src/command/pso.rs
+++ b/src/command/pso.rs
@@ -22,9 +22,6 @@ pub fn sign<const R: usize, T: trussed::Client>(
         return Err(Status::SecurityStatusNotSatisfied);
     }
 
-    if !ctx.state.internal.pw1_valid_multiple() {
-        ctx.state.runtime.sign_verified = false;
-    }
     if ctx.state.internal.uif(KeyType::Sign).is_enabled()
         && !ctx
             .backend
@@ -32,9 +29,11 @@ pub fn sign<const R: usize, T: trussed::Client>(
             .map_err(|_| Status::UnspecifiedNonpersistentExecutionError)?
     {
         warn!("User presence confirmation timed out");
-        ctx.state.runtime.sign_verified = true;
         // FIXME SecurityRelatedIssues (0x6600 is not available?)
         return Err(Status::SecurityStatusNotSatisfied);
+    }
+    if !ctx.state.internal.pw1_valid_multiple() {
+        ctx.state.runtime.sign_verified = false;
     }
 
     match ctx.state.internal.sign_alg() {


### PR DESCRIPTION
Setting the sign_verified flag to false and then setting it to true if
the user confirmation fails is a bit confusing.  Moving the reset after
the user confirmation should make the code more intuitive.

----

I didn’t want to add another iteration to #31 so I’m posting this suggested change as a PR instead.