### PR TITLE
Don't run ignored tests in make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,6 @@ fix:
 .PHONY: test
 test:
 	cargo test --features virtual
-	cargo test --features virtual --no-fail-fast -- --ignored || true
 
 .PHONY: fuzz
 fuzz: fuzz-corpus


### PR DESCRIPTION
We don't have any anymore and it just clutters the output