### PR TITLE
Fix curve25519 endianness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ SPDX-License-Identifier: CC0-1.0
 
 - Fix the length of the Digital signature counter DO 0x93 ([#76][])
 - PSO:CDS: Increment the signature counter ([#78][])
-- Fix endianness of curve25519 key impor([#89][])
+- Fix endianness of curve25519 key import([#89][])
 
 [#64]: https://github.com/Nitrokey/opcard-rs/pull/64
 [#60]: https://github.com/Nitrokey/opcard-rs/pull/60

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,14 @@ SPDX-License-Identifier: CC0-1.0
 
 - Fix the length of the Digital signature counter DO 0x93 ([#76][])
 - PSO:CDS: Increment the signature counter ([#78][])
+- Fix endianness of curve25519 key impor([#89][])
 
 [#64]: https://github.com/Nitrokey/opcard-rs/pull/64
 [#60]: https://github.com/Nitrokey/opcard-rs/pull/60
 [#63]: https://github.com/Nitrokey/opcard-rs/pull/63
 [#76]: https://github.com/Nitrokey/opcard-rs/pull/76
 [#78]: https://github.com/Nitrokey/opcard-rs/pull/78
+[#89]: https://github.com/Nitrokey/opcard-rs/pull/89
 
 ## v0.1.0 (2022-10-12)
 

--- a/tests/crypto-gpg-import.rs
+++ b/tests/crypto-gpg-import.rs
@@ -187,17 +187,24 @@ fn gpg_255() {
         let custom2 = format!(r"{temp_name} \(no comment\) <{temp_email}>");
         gnupg_test(
             &[DEFAULT_PW1],
-            &[vec![
-                r"\[GNUPG:\] ENC_TO [a-fA-F0-9]{16} \d* \d*",
-                r"\[GNUPG:\] DECRYPTION_KEY [a-fA-F0-9]{40} [a-fA-F0-9]{40} u",
-                r"\[GNUPG:\] BEGIN_DECRYPTION",
-                r"\[GNUPG:\] DECRYPTION_INFO \d \d \d",
-                r"\[GNUPG:\] PLAINTEXT \d* \d* Cargo.toml",
-                r"\[GNUPG:\] PLAINTEXT_LENGTH \d*",
-                r"\[GNUPG:\] DECRYPTION_OKAY",
-                r"\[GNUPG:\] GOODMDC",
-                r"\[GNUPG:\] END_DECRYPTION",
-            ]]
+            &[
+                vec![
+                    r"\[GNUPG:\] ENC_TO [a-fA-F0-9]{16} \d* \d*",
+                    &custom1,
+                    r"\[GNUPG:\] NEED_PASSPHRASE [a-fA-F0-9]{16} [a-fA-F0-9]{16} 18 0",
+                ],
+                virt::gpg_inquire_pin(),
+                vec![
+                    r"\[GNUPG:\] DECRYPTION_KEY [a-fA-F0-9]{40} [a-fA-F0-9]{40} u",
+                    r"\[GNUPG:\] BEGIN_DECRYPTION",
+                    r"\[GNUPG:\] DECRYPTION_INFO \d \d \d",
+                    r"\[GNUPG:\] PLAINTEXT \d* \d* Cargo.toml",
+                    r"\[GNUPG:\] PLAINTEXT_LENGTH \d*",
+                    r"\[GNUPG:\] DECRYPTION_OKAY",
+                    r"\[GNUPG:\] GOODMDC",
+                    r"\[GNUPG:\] END_DECRYPTION",
+                ],
+            ]
             .into_iter()
             .flatten()
             .collect::<Vec<&str>>(),


### PR DESCRIPTION
GPG doesn't exactly implement X25519, because it stores ECC scalars in Big-Endian format when the standardised X25519 operates with little endian scalars Therfore we need to reverse the endianness of the private key on key import.

This also highlight that the gpg-import test for X25519 was incorrect because the key import failed silently

Closes #84 