### PR TITLE
Fix OpenSC compatibility for RSA

### DIFF
--- a/src/command/data.rs
+++ b/src/command/data.rs
@@ -572,6 +572,8 @@ fn pw_status_bytes<const R: usize, T: trussed::Client>(
 }
 
 fn algo_info<const R: usize, T: trussed::Client>(mut ctx: Context<'_, R, T>) -> Result<(), Status> {
+    ctx.reply.expand(&[0xFA])?;
+    let offset = ctx.reply.len();
     for alg in SignatureAlgorithm::iter_all() {
         ctx.reply.expand(&[0xC1])?;
         let offset = ctx.reply.len();
@@ -590,6 +592,7 @@ fn algo_info<const R: usize, T: trussed::Client>(mut ctx: Context<'_, R, T>) -> 
         ctx.reply.expand(alg.attributes())?;
         ctx.reply.prepend_len(offset)?;
     }
+    ctx.reply.prepend_len(offset)?;
     Ok(())
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -58,6 +58,23 @@ const RSA_4K_ATTRIBUTES: &[u8] = hex!(
 )
 .as_slice();
 
+// Accepted for key generation, but overridden to always set the import format to CRT
+const RSA_2K_ATTRIBUTES_STANDARD_IMPORT: &[u8] = hex!("
+    01
+    0800 // Length modulus (in bit): 2048                                                                                                                                        
+    0020 // Length exponent (in bit): 32
+    00   // import in standard format
+").as_slice();
+const RSA_4K_ATTRIBUTES_STANDARD_IMPORT: &[u8] = hex!(
+    "
+    01
+    1000 // Length modulus (in bit): 4096
+    0020 // Length exponent (in bit): 32
+    00   // import in standard format
+"
+)
+.as_slice();
+
 #[derive(Debug, Copy, Clone)]
 pub struct AlgorithmFromAttributesError;
 
@@ -107,8 +124,8 @@ impl TryFrom<&[u8]> for SignatureAlgorithm {
         match v {
             ED255_ATTRIBUTES => Ok(Self::Ed255),
             ECDSA_P256_ATTRIBUTES => Ok(Self::EcDsaP256),
-            RSA_2K_ATTRIBUTES => Ok(Self::Rsa2048),
-            RSA_4K_ATTRIBUTES => Ok(Self::Rsa4096),
+            RSA_2K_ATTRIBUTES | RSA_2K_ATTRIBUTES_STANDARD_IMPORT => Ok(Self::Rsa2048),
+            RSA_4K_ATTRIBUTES | RSA_4K_ATTRIBUTES_STANDARD_IMPORT => Ok(Self::Rsa4096),
             _ => Err(AlgorithmFromAttributesError),
         }
     }
@@ -160,8 +177,8 @@ impl TryFrom<&[u8]> for DecryptionAlgorithm {
         match v {
             X255_ATTRIBUTES => Ok(Self::X255),
             ECDH_P256_ATTRIBUTES => Ok(Self::EcDhP256),
-            RSA_2K_ATTRIBUTES => Ok(Self::Rsa2048),
-            RSA_4K_ATTRIBUTES => Ok(Self::Rsa4096),
+            RSA_2K_ATTRIBUTES | RSA_2K_ATTRIBUTES_STANDARD_IMPORT => Ok(Self::Rsa2048),
+            RSA_4K_ATTRIBUTES | RSA_4K_ATTRIBUTES_STANDARD_IMPORT => Ok(Self::Rsa4096),
             _ => Err(AlgorithmFromAttributesError),
         }
     }
@@ -213,8 +230,8 @@ impl TryFrom<&[u8]> for AuthenticationAlgorithm {
         match v {
             ED255_ATTRIBUTES => Ok(Self::Ed255),
             ECDSA_P256_ATTRIBUTES => Ok(Self::EcDsaP256),
-            RSA_2K_ATTRIBUTES => Ok(Self::Rsa2048),
-            RSA_4K_ATTRIBUTES => Ok(Self::Rsa4096),
+            RSA_2K_ATTRIBUTES | RSA_2K_ATTRIBUTES_STANDARD_IMPORT => Ok(Self::Rsa2048),
+            RSA_4K_ATTRIBUTES | RSA_4K_ATTRIBUTES_STANDARD_IMPORT => Ok(Self::Rsa4096),
             _ => Err(AlgorithmFromAttributesError),
         }
     }


### PR DESCRIPTION
The opensc inability to generate RSA keys was due to OpenSC trying to set the algorithm attributes to a fixed byte string that was not exactly the one we accepted (because it specifies the Import even for key generation).