### PR TITLE
Update dependency overrides

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,11 +66,11 @@ log-warn = []
 log-error = []
 
 [patch.crates-io]
-# trussed = { git = "https://github.com/trussed-dev/trussed" , rev = "6de826f3bcbef247e55fd890d80d9ed6ce9f0abc" }
-trussed = { git = "https://github.com/nitrokey/trussed" , branch = "rsa-import" }
-littlefs2-sys = { git = "https://github.com/sosthene-nitrokey/littlefs2-sys.git", branch = "bindgen-runtime-feature" }
-interchange = { git = "https://github.com/trussed-dev/interchange.git", rev = "fe5633466640e1e9a8c06d9b5dd1d0af08c272af" }
-p256-cortex-m4 = { git = "https://github.com/sosthene-nitrokey/p256-cortex-m4.git", branch = "upgrade" }
+interchange = { git = "https://github.com/trussed-dev/interchange", rev = "fe5633466640e1e9a8c06d9b5dd1d0af08c272af" }
+littlefs2 = { git = "https://github.com/Nitrokey/littlefs2", tag = "v0.3.2-nitrokey-1" }
+littlefs2-sys = { git = "https://github.com/Nitrokey/littlefs2-sys", tag = "v0.1.6-nitrokey-1" }
+p256-cortex-m4 = { git = "https://github.com/Nitrokey/p256-cortex-m4", tag = "v0.1.0-alpha.6-nitrokey-1" }
+trussed = { git = "https://github.com/Nitrokey/trussed" , tag = "v0.1.0-nitrokey-4" }
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
This patch updates the dependency overrides for consistency with nitrokey-3-firmware, see:
	https://github.com/Nitrokey/nitrokey-3-firmware/blob/main/Cargo.toml
This has multiple benefits:
- By using tags instead of branch names, we are sure to operate on the same versions, even without a `Cargo.lock` file.
- It is easier to keep track of the currently used versions.
- We don’t risk to get out of sync with the actual firmware.

(As a side effect, this fixes an issue with the virtual trussed platform and the latest nightly Rust compiler.)