### PR TITLE
Allow access to children DOs

### DIFF
--- a/src/command/data.rs
+++ b/src/command/data.rs
@@ -458,7 +458,6 @@ pub fn get_data<const R: usize, T: trussed::Client>(
     })?;
     if !object.is_visible() {
         warn!("Get data for children object: {object:?}");
-        return Err(Status::IncorrectDataParameter);
     }
     debug!("Returning data for tag {:?}", tag);
     match object.simple_or_constructed() {


### PR DESCRIPTION
This is required by the Gnuk test suite.

It seems better to accept this instead of rejecting it, following the Robustness principle