### PR TITLE
Use external storage

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -41,7 +41,12 @@ impl<T: trussed::Client> Backend<T> {
     }
 
     /// Checks whether the given value matches the pin of the given type.
-    pub fn verify_pin(&mut self, pin: Password, value: &[u8], state: &mut state::Internal) -> bool {
+    pub fn verify_pin(
+        &mut self,
+        pin: Password,
+        value: &[u8],
+        state: &mut state::Persistent,
+    ) -> bool {
         state.verify_pin(&mut self.client, value, pin).is_ok()
     }
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -10,6 +10,7 @@
 use core::fmt::Debug;
 
 use trussed::try_syscall;
+use trussed::types::Location;
 
 use crate::command::Password;
 use crate::error::Error;
@@ -43,11 +44,14 @@ impl<T: trussed::Client> Backend<T> {
     /// Checks whether the given value matches the pin of the given type.
     pub fn verify_pin(
         &mut self,
+        storage: Location,
         pin: Password,
         value: &[u8],
         state: &mut state::Persistent,
     ) -> bool {
-        state.verify_pin(&mut self.client, value, pin).is_ok()
+        state
+            .verify_pin(&mut self.client, storage, value, pin)
+            .is_ok()
     }
 
     /// Ask for confirmation of presence from the user with a default timeout of 15 seconds

--- a/src/card.rs
+++ b/src/card.rs
@@ -196,7 +196,7 @@ impl<'a, const R: usize, T: trussed::Client> Context<'a, R, T> {
 }
 
 #[derive(Debug)]
-/// Context with the internal state loaded from flash
+/// Context with the persistent state loaded from flash
 pub struct LoadedContext<'a, const R: usize, T: trussed::Client> {
     pub backend: &'a mut Backend<T>,
     pub options: &'a Options,

--- a/src/card.rs
+++ b/src/card.rs
@@ -3,6 +3,7 @@
 
 use hex_literal::hex;
 use iso7816::Status;
+use trussed::types::Location;
 
 pub(crate) mod reply;
 
@@ -116,6 +117,8 @@ pub struct Options {
 
     /// Does the card have a button for user input?
     pub button_available: bool,
+    /// Which trussed storage to use
+    pub storage: Location,
 }
 
 impl Options {
@@ -153,6 +156,7 @@ impl Default for Options {
             // TODO: Copied from Nitrokey Pro
             historical_bytes: heapless::Vec::from_slice(&hex!("0031F573C00160009000")).unwrap(),
             button_available: true,
+            storage: Location::External,
         }
     }
 }
@@ -171,7 +175,7 @@ impl<'a, const R: usize, T: trussed::Client> Context<'a, R, T> {
         Ok(LoadedContext {
             state: self
                 .state
-                .load(self.backend.client_mut())
+                .load(self.backend.client_mut(), self.options.storage)
                 .map_err(|_| Status::UnspecifiedNonpersistentExecutionError)?,
             options: self.options,
             backend: self.backend,

--- a/src/command/data.rs
+++ b/src/command/data.rs
@@ -1336,7 +1336,7 @@ mod tests {
             let mut backend = crate::backend::Backend::new(client);
             let mut reply: heapless::Vec<u8, 1024> = Default::default();
             let runtime = Default::default();
-            let internal = state::Internal::test_default();
+            let internal = state::Persistent::test_default();
             let options = Default::default();
             let mut state = State {
                 internal: Some(internal),

--- a/src/command/gen.rs
+++ b/src/command/gen.rs
@@ -27,7 +27,7 @@ fn serialize_pub<const R: usize, T: trussed::Client>(
 pub fn sign<const R: usize, T: trussed::Client>(
     mut ctx: LoadedContext<'_, R, T>,
 ) -> Result<(), Status> {
-    let algo = ctx.state.internal.sign_alg();
+    let algo = ctx.state.persistent.sign_alg();
     info!("Generating sign key with algorithm: {algo:?}");
     match algo {
         SignatureAlgorithm::Ed255 => gen_ec_key(ctx.lend(), KeyType::Sign, CurveAlgo::Ed255),
@@ -49,7 +49,7 @@ pub fn sign<const R: usize, T: trussed::Client>(
 pub fn dec<const R: usize, T: trussed::Client>(
     mut ctx: LoadedContext<'_, R, T>,
 ) -> Result<(), Status> {
-    let algo = ctx.state.internal.dec_alg();
+    let algo = ctx.state.persistent.dec_alg();
     info!("Generating dec key with algorithm: {algo:?}");
     match algo {
         DecryptionAlgorithm::X255 => gen_ec_key(ctx.lend(), KeyType::Dec, CurveAlgo::X255),
@@ -69,7 +69,7 @@ pub fn dec<const R: usize, T: trussed::Client>(
 pub fn aut<const R: usize, T: trussed::Client>(
     mut ctx: LoadedContext<'_, R, T>,
 ) -> Result<(), Status> {
-    let algo = ctx.state.internal.aut_alg();
+    let algo = ctx.state.persistent.aut_alg();
     info!("Generating aut key with algorithm: {algo:?}");
     match algo {
         AuthenticationAlgorithm::Ed255 => gen_ec_key(ctx.lend(), KeyType::Aut, CurveAlgo::Ed255),
@@ -107,7 +107,7 @@ fn gen_rsa_key<const R: usize, T: trussed::Client>(
 
     if let Some((old_key, _)) = ctx
         .state
-        .internal
+        .persistent
         .set_key_id(key, Some((key_id, KeyOrigin::Generated)), client)
         .map_err(|_| Status::UnspecifiedNonpersistentExecutionError)?
     {
@@ -138,7 +138,7 @@ fn gen_ec_key<const R: usize, T: trussed::Client>(
     .key;
     if let Some((old_key, _)) = ctx
         .state
-        .internal
+        .persistent
         .set_key_id(key, Some((key_id, KeyOrigin::Generated)), client)
         .map_err(|_| Status::UnspecifiedNonpersistentExecutionError)?
     {
@@ -157,11 +157,11 @@ pub fn read_sign<const R: usize, T: trussed::Client>(
 ) -> Result<(), Status> {
     let key_id = ctx
         .state
-        .internal
+        .persistent
         .key_id(KeyType::Sign)
         .ok_or(Status::KeyReferenceNotFound)?;
 
-    let algo = ctx.state.internal.sign_alg();
+    let algo = ctx.state.persistent.sign_alg();
     match algo {
         SignatureAlgorithm::Ed255 => read_ec_key(ctx.lend(), key_id, CurveAlgo::Ed255),
         SignatureAlgorithm::EcDsaP256 => read_ec_key(ctx.lend(), key_id, CurveAlgo::EcDsaP256),
@@ -175,11 +175,11 @@ pub fn read_dec<const R: usize, T: trussed::Client>(
 ) -> Result<(), Status> {
     let key_id = ctx
         .state
-        .internal
+        .persistent
         .key_id(KeyType::Dec)
         .ok_or(Status::KeyReferenceNotFound)?;
 
-    let algo = ctx.state.internal.dec_alg();
+    let algo = ctx.state.persistent.dec_alg();
     match algo {
         DecryptionAlgorithm::X255 => read_ec_key(ctx.lend(), key_id, CurveAlgo::X255),
         DecryptionAlgorithm::EcDhP256 => read_ec_key(ctx.lend(), key_id, CurveAlgo::EcDhP256),
@@ -193,11 +193,11 @@ pub fn read_aut<const R: usize, T: trussed::Client>(
 ) -> Result<(), Status> {
     let key_id = ctx
         .state
-        .internal
+        .persistent
         .key_id(KeyType::Aut)
         .ok_or(Status::KeyReferenceNotFound)?;
 
-    let algo = ctx.state.internal.aut_alg();
+    let algo = ctx.state.persistent.aut_alg();
     match algo {
         AuthenticationAlgorithm::Ed255 => read_ec_key(ctx.lend(), key_id, CurveAlgo::Ed255),
         AuthenticationAlgorithm::EcDsaP256 => read_ec_key(ctx.lend(), key_id, CurveAlgo::EcDsaP256),

--- a/src/command/gen.rs
+++ b/src/command/gen.rs
@@ -97,7 +97,7 @@ fn gen_rsa_key<const R: usize, T: trussed::Client>(
     let client = ctx.backend.client_mut();
     let key_id = try_syscall!(client.generate_key(
         mechanism,
-        StorageAttributes::new().set_persistence(Location::Internal)
+        StorageAttributes::new().set_persistence(ctx.options.storage)
     ))
     .map_err(|_err| {
         error!("Failed to generate key: {_err:?}");
@@ -108,7 +108,12 @@ fn gen_rsa_key<const R: usize, T: trussed::Client>(
     if let Some((old_key, _)) = ctx
         .state
         .persistent
-        .set_key_id(key, Some((key_id, KeyOrigin::Generated)), client)
+        .set_key_id(
+            key,
+            Some((key_id, KeyOrigin::Generated)),
+            client,
+            ctx.options.storage,
+        )
         .map_err(|_| Status::UnspecifiedNonpersistentExecutionError)?
     {
         // Deletion is not a fatal error
@@ -129,7 +134,7 @@ fn gen_ec_key<const R: usize, T: trussed::Client>(
     let client = ctx.backend.client_mut();
     let key_id = try_syscall!(client.generate_key(
         curve.mechanism(),
-        StorageAttributes::new().set_persistence(Location::Internal)
+        StorageAttributes::new().set_persistence(ctx.options.storage)
     ))
     .map_err(|_err| {
         error!("Failed to generate key: {_err:?}");
@@ -139,7 +144,12 @@ fn gen_ec_key<const R: usize, T: trussed::Client>(
     if let Some((old_key, _)) = ctx
         .state
         .persistent
-        .set_key_id(key, Some((key_id, KeyOrigin::Generated)), client)
+        .set_key_id(
+            key,
+            Some((key_id, KeyOrigin::Generated)),
+            client,
+            ctx.options.storage,
+        )
         .map_err(|_| Status::UnspecifiedNonpersistentExecutionError)?
     {
         // Deletion is not a fatal error

--- a/src/command/private_key_template.rs
+++ b/src/command/private_key_template.rs
@@ -36,7 +36,7 @@ pub fn put_private_key_template<const R: usize, T: trussed::Client>(
 pub fn put_sign<const R: usize, T: trussed::Client>(
     mut ctx: LoadedContext<'_, R, T>,
 ) -> Result<(), Status> {
-    let attr = ctx.state.internal.sign_alg();
+    let attr = ctx.state.persistent.sign_alg();
     let key_id = match attr {
         SignatureAlgorithm::EcDsaP256 => put_ec(ctx.lend(), CurveAlgo::EcDsaP256)?,
         SignatureAlgorithm::Ed255 => put_ec(ctx.lend(), CurveAlgo::Ed255)?,
@@ -46,7 +46,7 @@ pub fn put_sign<const R: usize, T: trussed::Client>(
     .map(|key_id| (key_id, KeyOrigin::Imported));
     let old_key_id = ctx
         .state
-        .internal
+        .persistent
         .set_key_id(KeyType::Sign, key_id, ctx.backend.client_mut())
         .map_err(|_err| {
             error!("Failed to store new key: {_err:?}");
@@ -61,7 +61,7 @@ pub fn put_sign<const R: usize, T: trussed::Client>(
 pub fn put_dec<const R: usize, T: trussed::Client>(
     mut ctx: LoadedContext<'_, R, T>,
 ) -> Result<(), Status> {
-    let attr = ctx.state.internal.dec_alg();
+    let attr = ctx.state.persistent.dec_alg();
     let key_id = match attr {
         DecryptionAlgorithm::EcDhP256 => put_ec(ctx.lend(), CurveAlgo::EcDhP256)?,
         DecryptionAlgorithm::X255 => put_ec(ctx.lend(), CurveAlgo::X255)?,
@@ -71,7 +71,7 @@ pub fn put_dec<const R: usize, T: trussed::Client>(
     .map(|key_id| (key_id, KeyOrigin::Imported));
     let old_key_id = ctx
         .state
-        .internal
+        .persistent
         .set_key_id(KeyType::Dec, key_id, ctx.backend.client_mut())
         .map_err(|_err| {
             error!("Failed to store new key: {_err:?}");
@@ -86,7 +86,7 @@ pub fn put_dec<const R: usize, T: trussed::Client>(
 pub fn put_aut<const R: usize, T: trussed::Client>(
     mut ctx: LoadedContext<'_, R, T>,
 ) -> Result<(), Status> {
-    let attr = ctx.state.internal.aut_alg();
+    let attr = ctx.state.persistent.aut_alg();
     let key_id = match attr {
         AuthenticationAlgorithm::EcDsaP256 => put_ec(ctx.lend(), CurveAlgo::EcDsaP256)?,
         AuthenticationAlgorithm::Ed255 => put_ec(ctx.lend(), CurveAlgo::Ed255)?,
@@ -96,7 +96,7 @@ pub fn put_aut<const R: usize, T: trussed::Client>(
     .map(|key_id| (key_id, KeyOrigin::Imported));
     let old_key_id = ctx
         .state
-        .internal
+        .persistent
         .set_key_id(KeyType::Aut, key_id, ctx.backend.client_mut())
         .map_err(|_err| {
             error!("Failed to store new key: {_err:?}");

--- a/src/command/private_key_template.rs
+++ b/src/command/private_key_template.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 use iso7816::Status;
-use trussed::types::{KeyId, KeySerialization, Location, Mechanism};
+use trussed::types::{KeyId, KeySerialization, Mechanism};
 use trussed::{syscall, try_syscall};
 
 use crate::card::LoadedContext;
@@ -47,7 +47,12 @@ pub fn put_sign<const R: usize, T: trussed::Client>(
     let old_key_id = ctx
         .state
         .persistent
-        .set_key_id(KeyType::Sign, key_id, ctx.backend.client_mut())
+        .set_key_id(
+            KeyType::Sign,
+            key_id,
+            ctx.backend.client_mut(),
+            ctx.options.storage,
+        )
         .map_err(|_err| {
             error!("Failed to store new key: {_err:?}");
             Status::UnspecifiedNonpersistentExecutionError
@@ -72,7 +77,12 @@ pub fn put_dec<const R: usize, T: trussed::Client>(
     let old_key_id = ctx
         .state
         .persistent
-        .set_key_id(KeyType::Dec, key_id, ctx.backend.client_mut())
+        .set_key_id(
+            KeyType::Dec,
+            key_id,
+            ctx.backend.client_mut(),
+            ctx.options.storage,
+        )
         .map_err(|_err| {
             error!("Failed to store new key: {_err:?}");
             Status::UnspecifiedNonpersistentExecutionError
@@ -97,7 +107,12 @@ pub fn put_aut<const R: usize, T: trussed::Client>(
     let old_key_id = ctx
         .state
         .persistent
-        .set_key_id(KeyType::Aut, key_id, ctx.backend.client_mut())
+        .set_key_id(
+            KeyType::Aut,
+            key_id,
+            ctx.backend.client_mut(),
+            ctx.options.storage,
+        )
         .map_err(|_err| {
             error!("Failed to store new key: {_err:?}");
             Status::UnspecifiedNonpersistentExecutionError
@@ -143,7 +158,7 @@ fn put_ec<const R: usize, T: trussed::Client>(
     let key = try_syscall!(ctx.backend.client_mut().unsafe_inject_key(
         curve.mechanism(),
         message,
-        Location::Internal,
+        ctx.options.storage,
         KeySerialization::Raw
     ))
     .map_err(|_err| {
@@ -206,7 +221,7 @@ fn put_rsa<const R: usize, T: trussed::Client>(
     let key = try_syscall!(ctx.backend.client_mut().unsafe_inject_key(
         mechanism,
         &key_message,
-        Location::Internal,
+        ctx.options.storage,
         KeySerialization::RsaCrt
     ))
     .map_err(|_err| {

--- a/src/command/pso.rs
+++ b/src/command/pso.rs
@@ -46,14 +46,14 @@ pub fn sign<const R: usize, T: trussed::Client>(
         warn!("Attempt to sign without a key set");
         Status::KeyReferenceNotFound
     })?;
-    if !ctx.state.runtime.sign_verified {
+    if !ctx.state.volatile.sign_verified {
         warn!("Attempt to sign without PW1 verified");
         return Err(Status::SecurityStatusNotSatisfied);
     }
 
     check_uif(ctx.lend(), KeyType::Sign)?;
     if !ctx.state.persistent.pw1_valid_multiple() {
-        ctx.state.runtime.sign_verified = false;
+        ctx.state.volatile.sign_verified = false;
     }
     ctx.state
         .persistent
@@ -122,7 +122,7 @@ enum RsaOrEcc {
 fn int_aut_key_mecha_uif<const R: usize, T: trussed::Client>(
     ctx: LoadedContext<'_, R, T>,
 ) -> Result<(KeyId, Mechanism, bool, RsaOrEcc), Status> {
-    let (key_type, (mechanism, key_kind)) = match ctx.state.runtime.keyrefs.internal_aut {
+    let (key_type, (mechanism, key_kind)) = match ctx.state.volatile.keyrefs.internal_aut {
         KeyRef::Aut => (
             KeyType::Aut,
             match ctx.state.persistent.aut_alg() {
@@ -170,7 +170,7 @@ fn int_aut_key_mecha_uif<const R: usize, T: trussed::Client>(
 pub fn internal_authenticate<const R: usize, T: trussed::Client>(
     mut ctx: LoadedContext<'_, R, T>,
 ) -> Result<(), Status> {
-    if !ctx.state.runtime.other_verified {
+    if !ctx.state.volatile.other_verified {
         warn!("Attempt to sign without PW1 verified");
         return Err(Status::SecurityStatusNotSatisfied);
     }
@@ -189,7 +189,7 @@ pub fn internal_authenticate<const R: usize, T: trussed::Client>(
 fn decipher_key_mecha_uif<const R: usize, T: trussed::Client>(
     ctx: LoadedContext<'_, R, T>,
 ) -> Result<(KeyId, Mechanism, bool, RsaOrEcc), Status> {
-    let (key_type, (mechanism, key_kind)) = match ctx.state.runtime.keyrefs.pso_decipher {
+    let (key_type, (mechanism, key_kind)) = match ctx.state.volatile.keyrefs.pso_decipher {
         KeyRef::Dec => (
             KeyType::Dec,
             match ctx.state.persistent.dec_alg() {
@@ -229,7 +229,7 @@ fn decipher_key_mecha_uif<const R: usize, T: trussed::Client>(
 pub fn decipher<const R: usize, T: trussed::Client>(
     mut ctx: LoadedContext<'_, R, T>,
 ) -> Result<(), Status> {
-    if !ctx.state.runtime.other_verified {
+    if !ctx.state.volatile.other_verified {
         warn!("Attempt to sign without PW1 verified");
         return Err(Status::SecurityStatusNotSatisfied);
     }
@@ -390,7 +390,7 @@ fn decipher_aes<const R: usize, T: trussed::Client>(
 pub fn encipher<const R: usize, T: trussed::Client>(
     mut ctx: LoadedContext<'_, R, T>,
 ) -> Result<(), Status> {
-    if !ctx.state.runtime.other_verified {
+    if !ctx.state.volatile.other_verified {
         warn!("Attempt to encipher without PW1 verified");
         return Err(Status::SecurityStatusNotSatisfied);
     }

--- a/src/command/pso.rs
+++ b/src/command/pso.rs
@@ -57,7 +57,7 @@ pub fn sign<const R: usize, T: trussed::Client>(
     }
     ctx.state
         .persistent
-        .increment_sign_count(ctx.backend.client_mut())
+        .increment_sign_count(ctx.backend.client_mut(), ctx.options.storage)
         .map_err(|_err| {
             error!("Failed to increment sign count");
             Status::UnspecifiedPersistentExecutionError

--- a/src/command/pso.rs
+++ b/src/command/pso.rs
@@ -15,7 +15,7 @@ fn check_uif<const R: usize, T: trussed::Client>(
     ctx: LoadedContext<'_, R, T>,
     key: KeyType,
 ) -> Result<(), Status> {
-    if ctx.state.internal.uif(key).is_enabled() {
+    if ctx.state.persistent.uif(key).is_enabled() {
         prompt_uif(ctx)
     } else {
         Ok(())
@@ -42,7 +42,7 @@ fn prompt_uif<const R: usize, T: trussed::Client>(
 pub fn sign<const R: usize, T: trussed::Client>(
     mut ctx: LoadedContext<'_, R, T>,
 ) -> Result<(), Status> {
-    let key_id = ctx.state.internal.key_id(KeyType::Sign).ok_or_else(|| {
+    let key_id = ctx.state.persistent.key_id(KeyType::Sign).ok_or_else(|| {
         warn!("Attempt to sign without a key set");
         Status::KeyReferenceNotFound
     })?;
@@ -52,18 +52,18 @@ pub fn sign<const R: usize, T: trussed::Client>(
     }
 
     check_uif(ctx.lend(), KeyType::Sign)?;
-    if !ctx.state.internal.pw1_valid_multiple() {
+    if !ctx.state.persistent.pw1_valid_multiple() {
         ctx.state.runtime.sign_verified = false;
     }
     ctx.state
-        .internal
+        .persistent
         .increment_sign_count(ctx.backend.client_mut())
         .map_err(|_err| {
             error!("Failed to increment sign count");
             Status::UnspecifiedPersistentExecutionError
         })?;
 
-    match ctx.state.internal.sign_alg() {
+    match ctx.state.persistent.sign_alg() {
         SignatureAlgorithm::Ed255 => sign_ec(ctx, key_id, Mechanism::Ed255),
         SignatureAlgorithm::EcDsaP256 => {
             if ctx.data.len() != 32 {
@@ -125,7 +125,7 @@ fn int_aut_key_mecha_uif<const R: usize, T: trussed::Client>(
     let (key_type, (mechanism, key_kind)) = match ctx.state.runtime.keyrefs.internal_aut {
         KeyRef::Aut => (
             KeyType::Aut,
-            match ctx.state.internal.aut_alg() {
+            match ctx.state.persistent.aut_alg() {
                 AuthenticationAlgorithm::EcDsaP256 => (Mechanism::P256Prehashed, RsaOrEcc::Ecc),
                 AuthenticationAlgorithm::Ed255 => (Mechanism::Ed255, RsaOrEcc::Ecc),
 
@@ -135,7 +135,7 @@ fn int_aut_key_mecha_uif<const R: usize, T: trussed::Client>(
         ),
         KeyRef::Dec => (
             KeyType::Dec,
-            match ctx.state.internal.dec_alg() {
+            match ctx.state.persistent.dec_alg() {
                 DecryptionAlgorithm::X255 => {
                     warn!("Attempt to authenticate with X25519 key");
                     return Err(Status::ConditionsOfUseNotSatisfied);
@@ -156,12 +156,12 @@ fn int_aut_key_mecha_uif<const R: usize, T: trussed::Client>(
     }
 
     Ok((
-        ctx.state.internal.key_id(key_type).ok_or_else(|| {
+        ctx.state.persistent.key_id(key_type).ok_or_else(|| {
             warn!("Attempt to INTERNAL AUTHENTICATE without a key set");
             Status::KeyReferenceNotFound
         })?,
         mechanism,
-        ctx.state.internal.uif(key_type).is_enabled(),
+        ctx.state.persistent.uif(key_type).is_enabled(),
         key_kind,
     ))
 }
@@ -192,7 +192,7 @@ fn decipher_key_mecha_uif<const R: usize, T: trussed::Client>(
     let (key_type, (mechanism, key_kind)) = match ctx.state.runtime.keyrefs.pso_decipher {
         KeyRef::Dec => (
             KeyType::Dec,
-            match ctx.state.internal.dec_alg() {
+            match ctx.state.persistent.dec_alg() {
                 DecryptionAlgorithm::X255 => (Mechanism::X255, RsaOrEcc::Ecc),
                 DecryptionAlgorithm::EcDhP256 => (Mechanism::P256, RsaOrEcc::Ecc),
                 DecryptionAlgorithm::Rsa2048 => (Mechanism::Rsa2048Pkcs, RsaOrEcc::Rsa),
@@ -201,7 +201,7 @@ fn decipher_key_mecha_uif<const R: usize, T: trussed::Client>(
         ),
         KeyRef::Aut => (
             KeyType::Aut,
-            match ctx.state.internal.aut_alg() {
+            match ctx.state.persistent.aut_alg() {
                 AuthenticationAlgorithm::EcDsaP256 => (Mechanism::P256, RsaOrEcc::Ecc),
                 AuthenticationAlgorithm::Ed255 => {
                     warn!("Attempt to decipher with Ed255 key");
@@ -215,12 +215,12 @@ fn decipher_key_mecha_uif<const R: usize, T: trussed::Client>(
     };
 
     Ok((
-        ctx.state.internal.key_id(key_type).ok_or_else(|| {
+        ctx.state.persistent.key_id(key_type).ok_or_else(|| {
             warn!("Attempt to decrypt without a key set");
             Status::KeyReferenceNotFound
         })?,
         mechanism,
-        ctx.state.internal.uif(key_type).is_enabled(),
+        ctx.state.persistent.uif(key_type).is_enabled(),
         key_kind,
     ))
 }
@@ -361,7 +361,7 @@ fn decrypt_ec<const R: usize, T: trussed::Client>(
 fn decipher_aes<const R: usize, T: trussed::Client>(
     mut ctx: LoadedContext<'_, R, T>,
 ) -> Result<(), Status> {
-    let key_id = ctx.state.internal.aes_key().ok_or_else(|| {
+    let key_id = ctx.state.persistent.aes_key().ok_or_else(|| {
         warn!("Attempt to decipher with AES and no key set");
         Status::ConditionsOfUseNotSatisfied
     })?;
@@ -395,7 +395,7 @@ pub fn encipher<const R: usize, T: trussed::Client>(
         return Err(Status::SecurityStatusNotSatisfied);
     }
 
-    let key_id = ctx.state.internal.aes_key().ok_or_else(|| {
+    let key_id = ctx.state.persistent.aes_key().ok_or_else(|| {
         warn!("Attempt to decipher with AES and no key set");
         Status::ConditionsOfUseNotSatisfied
     })?;

--- a/src/state.rs
+++ b/src/state.rs
@@ -157,8 +157,8 @@ pub enum LifeCycle {
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct State {
-    // Internal state may not be loaded, or may error when loaded
-    pub internal: Option<Internal>,
+    // Persistent state may not be loaded, or may error when loaded
+    pub internal: Option<Persistent>,
     pub runtime: Runtime,
 }
 
@@ -177,13 +177,13 @@ impl State {
         //    })
         //} else {
         //    Ok(LoadedState {
-        //        internal: self.internal.insert(Internal::load(client)?),
+        //        internal: self.internal.insert(Persistent::load(client)?),
         //        runtime: &mut self.runtime,
         //    })
         //}
 
         if self.internal.is_none() {
-            self.internal = Some(Internal::load(client)?);
+            self.internal = Some(Persistent::load(client)?);
         }
 
         #[allow(clippy::unwrap_used)]
@@ -228,7 +228,7 @@ impl State {
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct LoadedState<'s> {
-    pub internal: &'s mut Internal,
+    pub internal: &'s mut Persistent,
     pub runtime: &'s mut Runtime,
 }
 
@@ -269,7 +269,7 @@ pub enum KeyOrigin {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Internal {
+pub struct Persistent {
     user_pin_tries: u8,
     admin_pin_tries: u8,
     reset_code_tries: u8,
@@ -297,7 +297,7 @@ pub struct Internal {
     uif_aut: Uif,
 }
 
-impl Internal {
+impl Persistent {
     const FILENAME: &'static str = "persistent-state.cbor";
     // § 4.3
     const MAX_RETRIES: u8 = 3;

--- a/src/state.rs
+++ b/src/state.rs
@@ -159,7 +159,7 @@ pub enum LifeCycle {
 pub struct State {
     // Persistent state may not be loaded, or may error when loaded
     pub persistent: Option<Persistent>,
-    pub runtime: Runtime,
+    pub volatile: Volatile,
 }
 
 impl State {
@@ -173,12 +173,12 @@ impl State {
         //if let Some(persistent) = self.persistent.as_mut() {
         //    Ok(LoadedState {
         //        persistent,
-        //        runtime: &mut self.runtime,
+        //        volatile: &mut self.volatile,
         //    })
         //} else {
         //    Ok(LoadedState {
         //        persistent: self.persistent.insert(Persistent::load(client)?),
-        //        runtime: &mut self.runtime,
+        //        volatile: &mut self.volatile,
         //    })
         //}
 
@@ -189,7 +189,7 @@ impl State {
         #[allow(clippy::unwrap_used)]
         Ok(LoadedState {
             persistent: self.persistent.as_mut().unwrap(),
-            runtime: &mut self.runtime,
+            volatile: &mut self.volatile,
         })
     }
 
@@ -229,7 +229,7 @@ impl State {
 #[derive(Debug, Eq, PartialEq)]
 pub struct LoadedState<'s> {
     pub persistent: &'s mut Persistent,
-    pub runtime: &'s mut Runtime,
+    pub volatile: &'s mut Volatile,
 }
 
 impl<'a> LoadedState<'a> {
@@ -240,7 +240,7 @@ impl<'a> LoadedState<'a> {
     pub fn lend(&mut self) -> LoadedState {
         LoadedState {
             persistent: self.persistent,
-            runtime: self.runtime,
+            volatile: self.volatile,
         }
     }
 }
@@ -762,7 +762,7 @@ impl Default for KeyRefs {
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct Runtime {
+pub struct Volatile {
     pub sign_verified: bool,
     pub other_verified: bool,
     pub admin_verified: bool,

--- a/src/state.rs
+++ b/src/state.rs
@@ -167,6 +167,7 @@ impl State {
     pub fn load<'s, T: trussed::Client>(
         &'s mut self,
         client: &mut T,
+        storage: Location,
     ) -> Result<LoadedState<'s>, Error> {
         // This would be the correct way but it doesn't compile because of
         // https://github.com/rust-lang/rust/issues/47680 (I think)
@@ -183,7 +184,7 @@ impl State {
         //}
 
         if self.persistent.is_none() {
-            self.persistent = Some(Persistent::load(client)?);
+            self.persistent = Some(Persistent::load(client, storage)?);
         }
 
         #[allow(clippy::unwrap_used)]
@@ -197,29 +198,30 @@ impl State {
     fn lifecycle_path() -> PathBuf {
         PathBuf::from(Self::LIFECYCLE_PATH)
     }
-    pub fn lifecycle(client: &mut impl trussed::Client) -> LifeCycle {
-        match try_syscall!(client.entry_metadata(Location::Internal, Self::lifecycle_path())) {
+    pub fn lifecycle(client: &mut impl trussed::Client, storage: Location) -> LifeCycle {
+        match try_syscall!(client.entry_metadata(storage, Self::lifecycle_path())) {
             Ok(Metadata { metadata: Some(_) }) => LifeCycle::Initialization,
             _ => LifeCycle::Operational,
         }
     }
 
-    pub fn terminate_df(client: &mut impl trussed::Client) -> Result<(), Status> {
-        try_syscall!(client.write_file(
-            Location::Internal,
-            Self::lifecycle_path(),
-            Bytes::new(),
-            None,
-        ))
-        .map(|_| {})
-        .map_err(|_err| {
-            error!("Failed to write lifecycle: {_err:?}");
-            Status::UnspecifiedPersistentExecutionError
-        })
+    pub fn terminate_df(
+        client: &mut impl trussed::Client,
+        storage: Location,
+    ) -> Result<(), Status> {
+        try_syscall!(client.write_file(storage, Self::lifecycle_path(), Bytes::new(), None,))
+            .map(|_| {})
+            .map_err(|_err| {
+                error!("Failed to write lifecycle: {_err:?}");
+                Status::UnspecifiedPersistentExecutionError
+            })
     }
 
-    pub fn activate_file(client: &mut impl trussed::Client) -> Result<(), Status> {
-        try_syscall!(client.remove_file(Location::Internal, Self::lifecycle_path(),)).ok();
+    pub fn activate_file(
+        client: &mut impl trussed::Client,
+        storage: Location,
+    ) -> Result<(), Status> {
+        try_syscall!(client.remove_file(storage, Self::lifecycle_path(),)).ok();
         // Errors can happen because of the removal of all files before the call to activate_file
         // so they are silenced
         Ok(())
@@ -344,8 +346,8 @@ impl Persistent {
         PathBuf::from(Self::FILENAME)
     }
 
-    pub fn load<T: trussed::Client>(client: &mut T) -> Result<Self, Error> {
-        if let Some(data) = load_if_exists(client, Location::Internal, &Self::path())? {
+    pub fn load<T: trussed::Client>(client: &mut T, storage: Location) -> Result<Self, Error> {
+        if let Some(data) = load_if_exists(client, storage, &Self::path())? {
             trussed::cbor_deserialize(&data).map_err(|_err| {
                 error!("failed to deserialize persistent state: {_err}");
                 Error::Loading
@@ -355,17 +357,15 @@ impl Persistent {
         }
     }
 
-    pub fn save<T: trussed::Client>(&self, client: &mut T) -> Result<(), Error> {
+    pub fn save<T: trussed::Client>(&self, client: &mut T, storage: Location) -> Result<(), Error> {
         let msg = trussed::cbor_serialize_bytes(&self).map_err(|_err| {
             error!("Failed to serialize: {_err}");
             Error::Saving
         })?;
-        try_syscall!(client.write_file(Location::Internal, Self::path(), msg, None)).map_err(
-            |_err| {
-                error!("Failed to store data: {_err:?}");
-                Error::Saving
-            },
-        )?;
+        try_syscall!(client.write_file(storage, Self::path(), msg, None)).map_err(|_err| {
+            error!("Failed to store data: {_err:?}");
+            Error::Saving
+        })?;
         Ok(())
     }
 
@@ -388,6 +388,7 @@ impl Persistent {
     pub fn decrement_counter<T: trussed::Client>(
         &mut self,
         client: &mut T,
+        storage: Location,
         password: Password,
     ) -> Result<(), Error> {
         if !self.is_locked(password) {
@@ -396,7 +397,7 @@ impl Persistent {
                 Password::Pw3 => self.admin_pin_tries += 1,
                 Password::ResetCode => self.reset_code_tries += 1,
             }
-            self.save(client)
+            self.save(client, storage)
         } else {
             Ok(())
         }
@@ -405,6 +406,7 @@ impl Persistent {
     pub fn reset_counter<T: trussed::Client>(
         &mut self,
         client: &mut T,
+        storage: Location,
         password: Password,
     ) -> Result<(), Error> {
         match password {
@@ -412,7 +414,7 @@ impl Persistent {
             Password::Pw3 => self.admin_pin_tries = 0,
             Password::ResetCode => self.reset_code_tries = 0,
         }
-        self.save(client)
+        self.save(client, storage)
     }
 
     fn pin(&self, password: Password) -> Option<&[u8]> {
@@ -426,6 +428,7 @@ impl Persistent {
     pub fn verify_pin<T: trussed::Client>(
         &mut self,
         client: &mut T,
+        storage: Location,
         value: &[u8],
         password: Password,
     ) -> Result<(), Error> {
@@ -433,13 +436,13 @@ impl Persistent {
             return Err(Error::TooManyTries);
         }
 
-        self.decrement_counter(client, password)?;
+        self.decrement_counter(client, storage, password)?;
         let pin = self.pin(password).ok_or(Error::BadRequest)?;
         if (!value.ct_eq(pin)).into() {
             return Err(Error::InvalidPin);
         }
 
-        self.reset_counter(client, password)?;
+        self.reset_counter(client, storage, password)?;
         Ok(())
     }
 
@@ -460,6 +463,7 @@ impl Persistent {
     pub fn change_pin<T: trussed::Client>(
         &mut self,
         client: &mut T,
+        storage: Location,
         value: &[u8],
         password: Password,
     ) -> Result<(), Error> {
@@ -478,13 +482,17 @@ impl Persistent {
         };
         *pin = new_pin;
         *tries = 0;
-        self.save(client)
+        self.save(client, storage)
     }
 
-    pub fn remove_reset_code<T: trussed::Client>(&mut self, client: &mut T) -> Result<(), Error> {
+    pub fn remove_reset_code<T: trussed::Client>(
+        &mut self,
+        client: &mut T,
+        storage: Location,
+    ) -> Result<(), Error> {
         self.reset_code_tries = 0;
         self.reset_code_pin = None;
-        self.save(client)
+        self.save(client, storage)
     }
 
     pub fn sign_alg(&self) -> SignatureAlgorithm {
@@ -494,14 +502,15 @@ impl Persistent {
     pub fn set_sign_alg(
         &mut self,
         client: &mut impl trussed::Client,
+        storage: Location,
         alg: SignatureAlgorithm,
     ) -> Result<(), Error> {
         if self.sign_alg == alg {
             return Ok(());
         }
-        self.delete_key(KeyType::Sign, client)?;
+        self.delete_key(KeyType::Sign, client, storage)?;
         self.sign_alg = alg;
-        self.save(client)
+        self.save(client, storage)
     }
 
     pub fn dec_alg(&self) -> DecryptionAlgorithm {
@@ -511,14 +520,15 @@ impl Persistent {
     pub fn set_dec_alg(
         &mut self,
         client: &mut impl trussed::Client,
+        storage: Location,
         alg: DecryptionAlgorithm,
     ) -> Result<(), Error> {
         if self.dec_alg == alg {
             return Ok(());
         }
-        self.delete_key(KeyType::Dec, client)?;
+        self.delete_key(KeyType::Dec, client, storage)?;
         self.dec_alg = alg;
-        self.save(client)
+        self.save(client, storage)
     }
 
     pub fn aut_alg(&self) -> AuthenticationAlgorithm {
@@ -528,14 +538,15 @@ impl Persistent {
     pub fn set_aut_alg(
         &mut self,
         client: &mut impl trussed::Client,
+        storage: Location,
         alg: AuthenticationAlgorithm,
     ) -> Result<(), Error> {
         if self.aut_alg == alg {
             return Ok(());
         }
-        self.delete_key(KeyType::Aut, client)?;
+        self.delete_key(KeyType::Aut, client, storage)?;
         self.aut_alg = alg;
-        self.save(client)
+        self.save(client, storage)
     }
 
     pub fn fingerprints(&self) -> Fingerprints {
@@ -545,10 +556,11 @@ impl Persistent {
     pub fn set_fingerprints(
         &mut self,
         client: &mut impl trussed::Client,
+        storage: Location,
         data: Fingerprints,
     ) -> Result<(), Error> {
         self.fingerprints = data;
-        self.save(client)
+        self.save(client, storage)
     }
 
     pub fn ca_fingerprints(&self) -> CaFingerprints {
@@ -558,10 +570,11 @@ impl Persistent {
     pub fn set_ca_fingerprints(
         &mut self,
         client: &mut impl trussed::Client,
+        storage: Location,
         data: CaFingerprints,
     ) -> Result<(), Error> {
         self.ca_fingerprints = data;
-        self.save(client)
+        self.save(client, storage)
     }
 
     pub fn keygen_dates(&self) -> KeyGenDates {
@@ -571,10 +584,11 @@ impl Persistent {
     pub fn set_keygen_dates(
         &mut self,
         client: &mut impl trussed::Client,
+        storage: Location,
         data: KeyGenDates,
     ) -> Result<(), Error> {
         self.keygen_dates = data;
-        self.save(client)
+        self.save(client, storage)
     }
 
     pub fn uif(&self, key: KeyType) -> Uif {
@@ -588,6 +602,7 @@ impl Persistent {
     pub fn set_uif(
         &mut self,
         client: &mut impl trussed::Client,
+        storage: Location,
         uif: Uif,
         key: KeyType,
     ) -> Result<(), Error> {
@@ -596,7 +611,7 @@ impl Persistent {
             KeyType::Dec => self.uif_dec = uif,
             KeyType::Aut => self.uif_aut = uif,
         }
-        self.save(client)
+        self.save(client, storage)
     }
 
     pub fn pw1_valid_multiple(&self) -> bool {
@@ -607,9 +622,10 @@ impl Persistent {
         &mut self,
         value: bool,
         client: &mut impl trussed::Client,
+        storage: Location,
     ) -> Result<(), Error> {
         self.pw1_valid_multiple = value;
-        self.save(client)
+        self.save(client, storage)
     }
 
     pub fn cardholder_name(&self) -> &[u8] {
@@ -620,9 +636,10 @@ impl Persistent {
         &mut self,
         value: Bytes<39>,
         client: &mut impl trussed::Client,
+        storage: Location,
     ) -> Result<(), Error> {
         self.cardholder_name = value;
-        self.save(client)
+        self.save(client, storage)
     }
 
     pub fn cardholder_sex(&self) -> Sex {
@@ -633,9 +650,10 @@ impl Persistent {
         &mut self,
         value: Sex,
         client: &mut impl trussed::Client,
+        storage: Location,
     ) -> Result<(), Error> {
         self.cardholder_sex = value;
-        self.save(client)
+        self.save(client, storage)
     }
 
     pub fn language_preferences(&self) -> &[u8] {
@@ -646,22 +664,27 @@ impl Persistent {
         &mut self,
         value: Bytes<8>,
         client: &mut impl trussed::Client,
+        storage: Location,
     ) -> Result<(), Error> {
         self.language_preferences = value;
-        self.save(client)
+        self.save(client, storage)
     }
 
     pub fn sign_count(&self) -> u32 {
         self.sign_count
     }
 
-    pub fn increment_sign_count(&mut self, client: &mut impl trussed::Client) -> Result<(), Error> {
+    pub fn increment_sign_count(
+        &mut self,
+        client: &mut impl trussed::Client,
+        storage: Location,
+    ) -> Result<(), Error> {
         self.sign_count += 1;
         // Sign count is returned on 3 bytes
         if self.sign_count & 0xffffff == 0 {
             self.sign_count = 0xffffff;
         }
-        self.save(client)
+        self.save(client, storage)
     }
 
     pub fn key_id(&self, ty: KeyType) -> Option<KeyId> {
@@ -688,6 +711,7 @@ impl Persistent {
         ty: KeyType,
         mut new: Option<(KeyId, KeyOrigin)>,
         client: &mut impl trussed::Client,
+        storage: Location,
     ) -> Result<Option<(KeyId, KeyOrigin)>, Error> {
         match ty {
             KeyType::Sign => {
@@ -697,7 +721,7 @@ impl Persistent {
             KeyType::Dec => swap(&mut self.confidentiality_key, &mut new),
             KeyType::Aut => swap(&mut self.aut_key, &mut new),
         }
-        self.save(client)?;
+        self.save(client, storage)?;
         Ok(new)
     }
 
@@ -709,9 +733,10 @@ impl Persistent {
         &mut self,
         mut new: Option<KeyId>,
         client: &mut impl trussed::Client,
+        storage: Location,
     ) -> Result<Option<KeyId>, Error> {
         swap(&mut self.aes_key, &mut new);
-        self.save(client)?;
+        self.save(client, storage)?;
         Ok(new)
     }
 
@@ -719,6 +744,7 @@ impl Persistent {
         &mut self,
         ty: KeyType,
         client: &mut impl trussed::Client,
+        storage: Location,
     ) -> Result<(), Error> {
         let key = match ty {
             KeyType::Sign => self.signing_key.take(),
@@ -727,7 +753,7 @@ impl Persistent {
         };
 
         if let Some((key_id, _)) = key {
-            self.save(client)?;
+            self.save(client, storage)?;
             try_syscall!(client.delete(key_id)).map_err(|_err| {
                 error!("Failed to delete key {_err:?}");
                 Error::Saving
@@ -831,22 +857,26 @@ impl ArbitraryDO {
     pub fn load(
         self,
         client: &mut impl trussed::Client,
+        storage: Location,
     ) -> Result<Bytes<MAX_GENERIC_LENGTH>, Error> {
-        load_if_exists(client, Location::Internal, &self.path())
+        load_if_exists(client, storage, &self.path())
             .map(|data| data.unwrap_or_else(|| self.default()))
     }
 
-    pub fn save(self, client: &mut impl trussed::Client, bytes: &[u8]) -> Result<(), Error> {
+    pub fn save(
+        self,
+        client: &mut impl trussed::Client,
+        storage: Location,
+        bytes: &[u8],
+    ) -> Result<(), Error> {
         let msg = Bytes::from(heapless::Vec::try_from(bytes).map_err(|_| {
             error!("Buffer full");
             Error::Saving
         })?);
-        try_syscall!(client.write_file(Location::Internal, self.path(), msg, None)).map_err(
-            |_err| {
-                error!("Failed to store data: {_err:?}");
-                Error::Saving
-            },
-        )?;
+        try_syscall!(client.write_file(storage, self.path(), msg, None)).map_err(|_err| {
+            error!("Failed to store data: {_err:?}");
+            Error::Saving
+        })?;
         Ok(())
     }
 }


### PR DESCRIPTION
This PR makes the storage used configurable via the options, and makes it to be `External` by default.

For better readability, it renames the `Internal` state to `Persistent` and the `Runtime` state to `Volatile`.

Open question: should we allow more granular control of the storage used? For example storing the keys on the Internal storage but storing the state in the external storage?