### PR TITLE
Update dangerous-real-tests to fix conflicts between sequoia, gpg-agent and pcscd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,10 @@
 # SPDX-License-Identifier: CC0-1.0
 
 export RUST_LOG ?= info,cargo_tarpaulin=off
-export OPCARD_DANGEROUS_TEST_CARD_VENDOR ?= 0000
-export OPCARD_DANGEROUS_TEST_CARD_SERIAL ?= 000000
+export OPCARD_DANGEROUS_TEST_CARD_USB_VENDOR ?= 0000
+export OPCARD_DANGEROUS_TEST_CARD_USB_PRODUCT ?= 000000
+export OPCARD_DANGEROUS_TEST_CARD_PGP_VENDOR ?= 0000
+export OPCARD_DANGEROUS_TEST_CARD_PGP_SERIAL ?= 000000
 export OPCARD_DANGEROUS_TEST_CARD_NAME ?= test card
 
 FUZZ_JOBS?=$(shell nproc)
@@ -37,7 +39,10 @@ test:
 
 .PHONY: test
 dangerous-real-card-test:
-	cargo test --features rsa4096,dangerous-test-real-card
+	ps aux | grep pcscd | grep -v grep || sudo pcscd
+	cargo test --features rsa4096,dangerous-test-real-card sequoia
+	sudo pkill pcscd
+	cargo test --features rsa4096,dangerous-test-real-card gpg
 
 .PHONY: fuzz
 fuzz: fuzz-corpus

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ The vendor id and serial numbers can be configured with variables:
 - `OPCARD_DANGEROUS_TEST_CARD_PGP_VENDOR` configures the PGP vendor id of the dveice
 - `OPCARD_DANGEROUS_TEST_CARD_PGP_PRODUCT` configures the PGP serial number of the dveice
 
+Be aware that due to conflicts between gpg-agent and `pcscd` (the smartcard daemon), this test suite will start then  stop `pcscd`
+
 ```
 make dangerous-real-card-test \
   OPCARD_DANGEROUS_TEST_CARD_USB_VENDOR="20A0" \

--- a/README.md
+++ b/README.md
@@ -47,8 +47,18 @@ Opcard uses [virtualsmartcard](https://frankmorgner.github.io/vsmartcard/) for t
 `make dangerous-real-card-test` will instead run the tests against a real card.
 The vendor id and serial numbers can be configured with variables:
 
+- `OPCARD_DANGEROUS_TEST_CARD_USB_VENDOR` configures the USB vendor id of the dveice
+- `OPCARD_DANGEROUS_TEST_CARD_USB_PRODUCT` configures the USB product id of the dveice
+- `OPCARD_DANGEROUS_TEST_CARD_PGP_VENDOR` configures the PGP vendor id of the dveice
+- `OPCARD_DANGEROUS_TEST_CARD_PGP_PRODUCT` configures the PGP serial number of the dveice
+
 ```
-make dangerous-real-card-test  OPCARD_DANGEROUS_TEST_CARD_VENDOR="0000" OPCARD_DANGEROUS_TEST_CARD_SERIAL="000000" OPCARD_DANGEROUS_TEST_CARD_NAME="test card"
+make dangerous-real-card-test \
+  OPCARD_DANGEROUS_TEST_CARD_USB_VENDOR="20A0" \
+  OPCARD_DANGEROUS_TEST_CARD_USB_PRODUCT="42B2" \
+  OPCARD_DANGEROUS_TEST_CARD_PGP_VENDOR="0000" \
+  OPCARD_DANGEROUS_TEST_CARD_PGP_SERIAL="A020DF77" \
+  OPCARD_DANGEROUS_TEST_CARD_NAME="test card"
 ```
 
 ## Installation

--- a/tests/crypto-sequoia.rs
+++ b/tests/crypto-sequoia.rs
@@ -20,9 +20,9 @@ use test_log::test;
 const IDENT: &str = "0000:00000000";
 #[cfg(feature = "dangerous-test-real-card")]
 const IDENT: &str = concat!(
-    env!("OPCARD_DANGEROUS_TEST_CARD_VENDOR"),
+    env!("OPCARD_DANGEROUS_TEST_CARD_PGP_VENDOR"),
     ":",
-    env!("OPCARD_DANGEROUS_TEST_CARD_SERIAL")
+    env!("OPCARD_DANGEROUS_TEST_CARD_PGP_SERIAL")
 );
 
 #[cfg(feature = "rsa2048")]
@@ -75,6 +75,7 @@ fn rsa2048() {
     let ciphertext = dec_pubk.encrypt(&session).unwrap();
     let mut decryptor = user_card.decryptor_from_public(dec_pubk, &|| {});
     assert_eq!(session, decryptor.decrypt(&ciphertext, None).unwrap());
+    open.factory_reset().unwrap();
 }
 
 #[cfg(feature = "rsa4096-gen")]
@@ -126,6 +127,7 @@ fn rsa4096() {
     let ciphertext = dec_pubk.encrypt(&session).unwrap();
     let mut decryptor = user_card.decryptor_from_public(dec_pubk, &|| {});
     assert_eq!(session, decryptor.decrypt(&ciphertext, None).unwrap());
+    open.factory_reset().unwrap();
 }
 
 fn p256() {
@@ -206,6 +208,7 @@ fn p256() {
     let ciphertext = aut_pubk_dec.encrypt(&session).unwrap();
     let mut decryptor = user_card.decryptor_from_public(aut_pubk_dec, &|| {});
     assert_eq!(session, decryptor.decrypt(&ciphertext, Some(32)).unwrap());
+    open.factory_reset().unwrap();
 }
 
 fn curve25519() {
@@ -278,6 +281,7 @@ fn curve25519() {
 
     // X25519 with and EdDSA key should fail
     decryptor.decrypt(&ciphertext, None).unwrap_err();
+    open.factory_reset().unwrap();
 }
 
 #[cfg(all(feature = "virtual", not(feature = "dangerous-test-real-card")))]

--- a/tests/virt/mod.rs
+++ b/tests/virt/mod.rs
@@ -177,19 +177,23 @@ pub fn gpg_status(key: KeyType, sign_count: usize) -> Vec<&'static str> {
     let (reader, serial, vendor) = (
         concat!(
             r"Reader:",
-            env!("OPCARD_DANGEROUS_TEST_CARD_VENDOR"),
+            env!("OPCARD_DANGEROUS_TEST_CARD_USB_VENDOR"),
             ":",
-            env!("OPCARD_DANGEROUS_TEST_CARD_SERIAL"),
+            env!("OPCARD_DANGEROUS_TEST_CARD_USB_PRODUCT"),
             ":X:0:AID:D276000124010304[A-Z0-9]*:openpgp-card"
         ),
         concat!(
             r"vendor:",
-            env!("OPCARD_DANGEROUS_TEST_CARD_VENDOR"),
+            env!("OPCARD_DANGEROUS_TEST_CARD_USB_VENDOR"),
             ":",
             env!("OPCARD_DANGEROUS_TEST_CARD_NAME"),
             ":"
         ),
-        concat!(r"serial:", env!("OPCARD_DANGEROUS_TEST_CARD_SERIAL"), ":"),
+        concat!(
+            r"serial:",
+            env!("OPCARD_DANGEROUS_TEST_CARD_USB_PRODUCT"),
+            ":"
+        ),
     );
 
     [


### PR DESCRIPTION
Before this fix there were some issues:

1. gpg needed the usb vendor/product ids while sequoia needed the gpg vendor id and serial number. This PR makes the two configurable with distinct variables
2. running the seqouia tests after the gpg ones caused a conflict because gpg-agent held the card so pcscd didn't see it, and vice-versa. So the tests now:
   1. Start pcscd (if not already started)
   2. run the sequoia tests
   3. kill pcscd
   4. run the gpg tests. 