### PR TITLE
Remove RUSTFLAGS in make lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ check:
 
 .PHONY: lint
 lint:
-	RUSTFLAGS='-Dwarnings' cargo check --all-features --all-targets --workspace
+	cargo check --all-features --all-targets --workspace
 	cargo check --no-default-features --all-targets
 	cargo clippy --all-features --all-targets -- --deny warnings
 	cargo fmt -- --check


### PR DESCRIPTION
Cargo recompiles everything when the RUSTFLAGS change so this makes lint slower than they need to be. Removing this doesn't miss any lints because the clippy pass also has `--deny warnings`