### PR TITLE
Use serialization helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ SPDX-License-Identifier: CC0-1.0
 
 # Changelog
 
+## Unreleased
+
+### Changes
+
+- Use stable serialization helpers instead of postcard directly.
+
 ## [v0.4.0][] (2023-02-24)
 
 ### Features

--- a/src/command/gen.rs
+++ b/src/command/gen.rs
@@ -301,11 +301,10 @@ fn read_rsa_key<const R: usize, T: trussed::Client + AuthClient>(
                 Status::UnspecifiedNonpersistentExecutionError
             })?
             .serialized_key;
-    let parsed_pubkey_data: RsaPublicParts =
-        trussed::postcard_deserialize(&pubkey_data).map_err(|_err| {
-            error!("Failed to deserialize public key");
-            Status::UnspecifiedNonpersistentExecutionError
-        })?;
+    let parsed_pubkey_data = RsaPublicParts::deserialize(&pubkey_data).map_err(|_err| {
+        error!("Failed to deserialize public key");
+        Status::UnspecifiedNonpersistentExecutionError
+    })?;
     ctx.reply.expand(&[0x81])?;
     ctx.reply.append_len(parsed_pubkey_data.n.len())?;
     ctx.reply.expand(parsed_pubkey_data.n)?;

--- a/src/command/private_key_template.rs
+++ b/src/command/private_key_template.rs
@@ -208,14 +208,12 @@ fn put_rsa<const R: usize, T: trussed::Client + AuthClient>(
     ctx: LoadedContext<'_, R, T>,
     mechanism: Mechanism,
 ) -> Result<Option<(KeyId, KeyId)>, Status> {
-    use trussed::{postcard_serialize_bytes, types::SerializedKey};
-
     let key_data = parse_rsa_template(ctx.data).ok_or_else(|| {
         warn!("Unable to parse RSA key");
         Status::IncorrectDataParameter
     })?;
 
-    let key_message: SerializedKey = postcard_serialize_bytes(&key_data).map_err(|_err| {
+    let key_message = key_data.serialize().map_err(|_err| {
         error!("Failed to serialize RSA key: {_err:?}");
         Status::UnspecifiedNonpersistentExecutionError
     })?;


### PR DESCRIPTION
Instead of using Trussed’s re-exports of postcard that will be removed in Trussed 0.2.0, we use the public and stable  serialization helper methods.
