### PR TITLE
Return 6285 for SELECT in termination state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ SPDX-License-Identifier: CC0-1.0
 
 ## Unreleased
 
+### Bugfixes
+
+- Return status 6285 if SELECT is called in termination state ([#154][])
+
+[#154]: https://github.com/Nitrokey/opcard-rs/issues/154
+
 ## [v1.0.0][] (2023-04-27)
 
 - Add support for larger storage for certificates and private use data objects ([#150][])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ log-warn = []
 log-error = []
 
 [patch.crates-io]
+iso7816 = { git = "https://github.com/Nitrokey/iso7816.git", tag = "v0.1.1-nitrokey.1" }
 p256-cortex-m4 = { git = "https://github.com/Nitrokey/p256-cortex-m4", tag = "v0.1.0-alpha.6-nitrokey-1" }
 trussed = { git = "https://github.com/trussed-dev/trussed" , rev = "55ea391367fce4bf5093ff2d3c79041d7aef0485" }
 trussed-auth = { git = "https://github.com/trussed-dev/trussed-auth.git", tag = "v0.2.2"}


### PR DESCRIPTION
This patch changes the status code for SELECT APDUs to 6285 if the card is in termination/initialization state.

Fixes: https://github.com/Nitrokey/opcard-rs/issues/154

Depends on : https://github.com/Nitrokey/iso7816/pull/1