### PR TITLE
Limit usage of volatile storage

### DIFF
--- a/src/command/pso.rs
+++ b/src/command/pso.rs
@@ -42,10 +42,9 @@ fn prompt_uif<const R: usize, T: crate::card::Client>(
 pub fn sign<const R: usize, T: crate::card::Client>(
     mut ctx: LoadedContext<'_, R, T>,
 ) -> Result<(), Status> {
-    let key_id =
-        ctx.state
-            .volatile
-            .key_id(ctx.backend.client_mut(), KeyType::Sign, ctx.options.storage)?;
+    let key_id = ctx
+        .state
+        .key_id(ctx.backend.client_mut(), KeyType::Sign, ctx.options.storage)?;
 
     check_uif(ctx.lend(), KeyType::Sign)?;
     let sign_result = ctx
@@ -119,7 +118,7 @@ enum RsaOrEcc {
 }
 
 fn int_aut_key_mecha_uif<const R: usize, T: crate::card::Client>(
-    ctx: LoadedContext<'_, R, T>,
+    mut ctx: LoadedContext<'_, R, T>,
 ) -> Result<(KeyId, Mechanism, bool, RsaOrEcc), Status> {
     let (key_type, (mechanism, key_kind)) = match ctx.state.volatile.keyrefs.internal_aut {
         KeyRef::Aut => (
@@ -158,7 +157,6 @@ fn int_aut_key_mecha_uif<const R: usize, T: crate::card::Client>(
 
     Ok((
         ctx.state
-            .volatile
             .key_id(ctx.backend.client_mut(), key_type, ctx.options.storage)?,
         mechanism,
         ctx.state.persistent.uif(key_type).is_enabled(),
@@ -187,7 +185,7 @@ pub fn internal_authenticate<const R: usize, T: crate::card::Client>(
 }
 
 fn decipher_key_mecha_uif<const R: usize, T: crate::card::Client>(
-    ctx: LoadedContext<'_, R, T>,
+    mut ctx: LoadedContext<'_, R, T>,
 ) -> Result<(KeyId, Mechanism, bool, RsaOrEcc), Status> {
     let (key_type, (mechanism, key_kind)) = match ctx.state.volatile.keyrefs.pso_decipher {
         KeyRef::Dec => (
@@ -218,7 +216,6 @@ fn decipher_key_mecha_uif<const R: usize, T: crate::card::Client>(
 
     Ok((
         ctx.state
-            .volatile
             .key_id(ctx.backend.client_mut(), key_type, ctx.options.storage)?,
         mechanism,
         ctx.state.persistent.uif(key_type).is_enabled(),

--- a/src/state.rs
+++ b/src/state.rs
@@ -533,8 +533,8 @@ impl<'a> LoadedState<'a> {
     ) -> Result<KeyId, Status> {
         use KeyType as K;
         use UserVerifiedInner as V;
-        // Self::clear_cached is there to avoid having multiple keys in the volatile storage.
-        // RSA keys can be up 2300 bytes out of the total 8000.
+        // Self::limit_cache_size is there to avoid having multiple keys in the volatile storage.
+        // RSA keys can be up 2.3KB out of the total 8KiB.
         // With 3 keys this gets us very close to being full, especially with the added overhead of littlefs metadata
         //
         // Therefore we never cache more than 1 key

--- a/src/state.rs
+++ b/src/state.rs
@@ -509,6 +509,86 @@ impl<'a> LoadedState<'a> {
         self.persistent.save(client, storage)?;
         Ok(())
     }
+
+    /// Avoid having too many RSA keys in volatile storage
+    fn limit_cache_size(
+        client: &mut impl crate::card::Client,
+        keys: &mut [(&mut Option<KeyId>, bool)],
+    ) {
+        for key in keys
+            .iter_mut()
+            .filter_map(|(k, is_rsa)| if *is_rsa { Some(k.take()) } else { None })
+            .flatten()
+        {
+            syscall!(client.delete(key));
+        }
+    }
+
+    /// Returns the requested key
+    pub fn key_id(
+        &mut self,
+        client: &mut impl crate::card::Client,
+        key: KeyType,
+        storage: Location,
+    ) -> Result<KeyId, Status> {
+        // Self::clear_cached is there to avoid having multiple keys in the volatile storage.
+        // RSA keys can be up 2300 bytes out of the total 8000.
+        // With 3 keys this gets us very close to being full, especially with the added overhead of littlefs metadata
+        //
+        // Therefore we never cache more than 1 key
+        match (&mut self.volatile.user.0, key) {
+            (UserVerifiedInner::None, _) => Err(Status::SecurityStatusNotSatisfied),
+            (
+                UserVerifiedInner::Sign(user_kek, cache)
+                | UserVerifiedInner::OtherAndSign(user_kek, cache),
+                KeyType::Sign,
+            ) => {
+                Self::limit_cache_size(
+                    client,
+                    &mut [
+                        (&mut cache.dec, self.persistent.dec_alg.is_rsa()),
+                        (&mut cache.aut, self.persistent.aut_alg.is_rsa()),
+                    ],
+                );
+                Volatile::load_or_get_key(
+                    client,
+                    *user_kek,
+                    &mut cache.sign,
+                    SIGNING_KEY_PATH,
+                    storage,
+                )
+            }
+            (
+                UserVerifiedInner::Other(user_kek, cache)
+                | UserVerifiedInner::OtherAndSign(user_kek, cache),
+                KeyType::Aut,
+            ) => {
+                Self::limit_cache_size(
+                    client,
+                    &mut [
+                        (&mut cache.sign, self.persistent.sign_alg.is_rsa()),
+                        (&mut cache.dec, self.persistent.dec_alg.is_rsa()),
+                    ],
+                );
+                Volatile::load_or_get_key(client, *user_kek, &mut cache.aut, AUTH_KEY_PATH, storage)
+            }
+            (
+                UserVerifiedInner::Other(user_kek, cache)
+                | UserVerifiedInner::OtherAndSign(user_kek, cache),
+                KeyType::Dec,
+            ) => {
+                Self::limit_cache_size(
+                    client,
+                    &mut [
+                        (&mut cache.sign, self.persistent.sign_alg.is_rsa()),
+                        (&mut cache.aut, self.persistent.aut_alg.is_rsa()),
+                    ],
+                );
+                Volatile::load_or_get_key(client, *user_kek, &mut cache.dec, DEC_KEY_PATH, storage)
+            }
+            _ => Err(Status::SecurityStatusNotSatisfied),
+        }
+    }
 }
 
 enum_u8! {
@@ -1292,39 +1372,6 @@ impl Volatile {
             | UserVerifiedInner::OtherAndSign(user_kek, cache) => {
                 Self::load_or_get_key(client, *user_kek, &mut cache.aes, AES_KEY_PATH, storage)
             }
-        }
-    }
-    /// Returns the requested key
-    pub fn key_id(
-        &mut self,
-        client: &mut impl crate::card::Client,
-        key: KeyType,
-        storage: Location,
-    ) -> Result<KeyId, Status> {
-        match (&mut self.user.0, key) {
-            (UserVerifiedInner::None, _) => Err(Status::SecurityStatusNotSatisfied),
-            (
-                UserVerifiedInner::Sign(user_kek, cache)
-                | UserVerifiedInner::OtherAndSign(user_kek, cache),
-                KeyType::Sign,
-            ) => Self::load_or_get_key(
-                client,
-                *user_kek,
-                &mut cache.sign,
-                SIGNING_KEY_PATH,
-                storage,
-            ),
-            (
-                UserVerifiedInner::Other(user_kek, cache)
-                | UserVerifiedInner::OtherAndSign(user_kek, cache),
-                KeyType::Aut,
-            ) => Self::load_or_get_key(client, *user_kek, &mut cache.aut, AUTH_KEY_PATH, storage),
-            (
-                UserVerifiedInner::Other(user_kek, cache)
-                | UserVerifiedInner::OtherAndSign(user_kek, cache),
-                KeyType::Dec,
-            ) => Self::load_or_get_key(client, *user_kek, &mut cache.dec, DEC_KEY_PATH, storage),
-            _ => Err(Status::SecurityStatusNotSatisfied),
         }
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -125,6 +125,10 @@ impl SignatureAlgorithm {
         self.attributes()[0]
     }
 
+    pub fn is_rsa(&self) -> bool {
+        matches!(self, Self::Rsa2048 | Self::Rsa3072 | Self::Rsa4096)
+    }
+
     pub fn attributes(&self) -> &'static [u8] {
         match self {
             Self::Ed255 => ED255_ATTRIBUTES,
@@ -181,6 +185,10 @@ impl DecryptionAlgorithm {
         self.attributes()[0]
     }
 
+    pub fn is_rsa(&self) -> bool {
+        matches!(self, Self::Rsa2048 | Self::Rsa3072 | Self::Rsa4096)
+    }
+
     pub fn attributes(&self) -> &'static [u8] {
         match self {
             Self::X255 => X255_ATTRIBUTES,
@@ -235,6 +243,10 @@ impl AuthenticationAlgorithm {
     #[allow(unused)]
     pub fn id(&self) -> u8 {
         self.attributes()[0]
+    }
+
+    pub fn is_rsa(&self) -> bool {
+        matches!(self, Self::Rsa2048 | Self::Rsa3072 | Self::Rsa4096)
     }
 
     pub fn attributes(&self) -> &'static [u8] {


### PR DESCRIPTION
This PR limit the number of private RSA key in volatile storage to 1. 

See https://github.com/Nitrokey/nitrokey-3-firmware/issues/283#issuecomment-1587509088 for more context.