### PR TITLE
Add selection of interface so that Opcard only accept one of them.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,8 @@ log-warn = []
 log-error = []
 
 [patch.crates-io]
-iso7816 = { git = "https://github.com/Nitrokey/iso7816.git", tag = "v0.1.1-nitrokey.1" }
+apdu-dispatch = { git = "https://github.com/trussed-dev/apdu-dispatch.git", rev = "3c6722d01bb9aea13b1b7a1fb0d5ec23d5a39d6a" }
+iso7816 = { git = "https://github.com/Nitrokey/iso7816.git", rev = "82971bac269205dec7e6d0d371306f76b5d77442" }
 p256-cortex-m4 = { git = "https://github.com/Nitrokey/p256-cortex-m4", tag = "v0.1.0-alpha.6-nitrokey-1" }
 trussed = { git = "https://github.com/trussed-dev/trussed" , rev = "55ea391367fce4bf5093ff2d3c79041d7aef0485" }
 trussed-auth = { git = "https://github.com/trussed-dev/trussed-auth.git", tag = "v0.2.2"}

--- a/src/card.rs
+++ b/src/card.rs
@@ -91,18 +91,25 @@ impl<T: Client> iso7816::App for Card<T> {
 impl<T: Client, const C: usize, const R: usize> apdu_dispatch::App<C, R> for Card<T> {
     fn select(
         &mut self,
+        interface: apdu_dispatch::dispatch::Interface,
         command: &iso7816::Command<C>,
         reply: &mut heapless::Vec<u8, R>,
     ) -> Result<(), Status> {
+        if interface != self.options.interface {
+            return Err(Status::FunctionNotSupported);
+        }
         self.handle(command, reply)
     }
 
     fn call(
         &mut self,
-        _interface: apdu_dispatch::dispatch::Interface,
+        interface: apdu_dispatch::dispatch::Interface,
         command: &iso7816::Command<C>,
         reply: &mut heapless::Vec<u8, R>,
     ) -> Result<(), Status> {
+        if interface != self.options.interface {
+            return Err(Status::FunctionNotSupported);
+        }
         self.handle(command, reply)
     }
 
@@ -128,6 +135,9 @@ pub struct Options {
     pub button_available: bool,
     /// Which trussed storage to use
     pub storage: Location,
+
+    /// Which Interface should opcard accept calls from (Opcard cannot accept calls from both without being restarted in any circumstance)
+    pub interface: iso7816::Interface,
 }
 
 impl Options {
@@ -166,6 +176,7 @@ impl Default for Options {
             historical_bytes: heapless::Vec::from_slice(&hex!("0031F573C00160009000")).unwrap(),
             button_available: true,
             storage: Location::External,
+            interface: iso7816::Interface::Contact,
         }
     }
 }


### PR DESCRIPTION
Supporting both interfaces concurrently would require duplicating the runtime state to prevent sharing of the authorization layer.

Currently no Nitrokey device supports NFC for OpenPGP, this can also disable support for it.

Depends on https://github.com/trussed-dev/apdu-dispatch/pull/18