### PR TITLE
Fix missing save after state initialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ trussed = { git = "https://github.com/trussed-dev/trussed" , rev = "55ea391367fc
 trussed-auth = { git = "https://github.com/trussed-dev/trussed-auth.git", tag = "v0.2.2"}
 trussed-rsa-alloc = { git = "https://github.com/Nitrokey/trussed-rsa-backend", tag = "v0.1.0" }
 trussed-staging = { git = "https://github.com/Nitrokey/trussed-staging", tag = "v0.1.0" }
+delog = { git = "https://github.com/trussed-dev/delog.git", rev = "2191ed1a3bdca09158afd8e96fb979e570be5fe4"}
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/state.rs
+++ b/src/state.rs
@@ -743,7 +743,9 @@ impl Persistent {
             })
         } else {
             Self::init_pins(client, storage)?;
-            Ok(Self::default())
+            let this = Self::default();
+            this.save(client, storage)?;
+            Ok(this)
         }
     }
 


### PR DESCRIPTION
Previously, the initialization didn't save the state. This meant that if the first use did not cause a save of the state, the PINs would be initialized but not the state, which would make next loading attempts fail.