### PR TITLE
ci: move include to internal repository

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,10 @@
 # Copyright (C) 2022 Nitrokey GmbH
 # SPDX-License-Identifier: CC0-1.0
 
-include: 'https://raw.githubusercontent.com/Nitrokey/common-ci-jobs/master/common_jobs.yml'
+include:                                                                                             
+  - project: 'nitrokey/gitlab-ci'                                                                    
+    file:                                                                                            
+      - 'common-jobs/common_jobs.yml' 
 
 stages:
   - pull-github


### PR DESCRIPTION
moving the reference for the include away from github to our internal git(lab)