### PR TITLE
Add variables.mk to Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ fuzz/coverage
 fuzz_coverage.html
 tarpaulin-report.html
 cobertura.xml
+variables.mk

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 # Copyright (C) 2022 Nitrokey GmbH
 # SPDX-License-Identifier: CC0-1.0
 
+-include variables.mk
+
 export RUST_LOG ?= info,cargo_tarpaulin=off
 export OPCARD_DANGEROUS_TEST_CARD_USB_VENDOR ?= 0000
 export OPCARD_DANGEROUS_TEST_CARD_USB_PRODUCT ?= 000000


### PR DESCRIPTION
This patch adds an optional include of variables.mk to the Makefile and also adds that file to the gitignore list.  This means that e. g. the OPCARD_DANGEROUS_TEST_* variables can be overwritten outside of version control.