### PR TITLE
Require sha1collisiondetection 0.2.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,10 @@ hex = { version = "0.4", features = ["serde"] }
 # usbip
 trussed-usbip = { git = "https://github.com/trussed-dev/pc-usbip-runner", default-features = false, features = ["ccid"], rev = "f3a680ca4c9a1411838ae0774f1713f79d4c2979" }
 
+# sequoia-openpgp depends on sha1collisiondetection >= 0.2.3, but only 0.2.7 works with newer Rust versions.
+# This can be removed once sequoia-openpgp is updated to a version > 1.16.1.
+sha1collisiondetection = "0.2.7"
+
 [features]
 default = []
 std = []


### PR DESCRIPTION
This fixes an misaligned pointer dereference with newer Rust versions. Upstream issue:
    https://gitlab.com/sequoia-pgp/sha1collisiondetection/-/issues/7