### PR TITLE
Fix sha1collisiondetection being duplicated with recent version of sequoia-openpgp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ vpicc = { version = "0.1.0", optional = true }
 env_logger = "0.9"
 openpgp-card = "0.3"
 openpgp-card-sequoia = "0.1.2"
-sequoia-openpgp = "1.10.0"
+sequoia-openpgp = "1.17.0"
 openpgp-card-pcsc = "0.3"
 regex = "1.6.0"
 stoppable_thread = "0.2.1"
@@ -60,10 +60,6 @@ hex = { version = "0.4", features = ["serde"] }
 
 # usbip
 trussed-usbip = { git = "https://github.com/trussed-dev/pc-usbip-runner", default-features = false, features = ["ccid"], rev = "f3a680ca4c9a1411838ae0774f1713f79d4c2979" }
-
-# sequoia-openpgp depends on sha1collisiondetection >= 0.2.3, but only 0.2.7 works with newer Rust versions.
-# This can be removed once sequoia-openpgp is updated to a version > 1.16.1.
-sha1collisiondetection = "0.2.7"
 
 [features]
 default = []


### PR DESCRIPTION

The version of sha1collisiondetection was added to avoid an issue with earlier releases. Latest release of sequoia-openpgp uses v0.3.1 which already fixes the issue