### PR TITLE
Update dockerfile

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,17 +1,14 @@
 # Copyright (C) 2022 Nitrokey GmbH
 # SPDX-License-Identifier: CC0-1.0
 
-FROM docker.io/rust:latest
+FROM docker.io/rust:bullseye
 
-RUN apt update
+RUN apt update && apt upgrade --yes
 RUN apt install --yes gnupg scdaemon libclang-dev llvm python3-pip vsmartcard-vpcd pkg-config nettle-dev libpcsclite-dev
-
 RUN python3 -m pip install reuse
 
 RUN rustup component add clippy rustfmt && rustup toolchain install nightly
 RUN cargo install cargo-tarpaulin cargo-fuzz --profile release && rm -rf "$CARGO_HOME"/registry
-# initialize cargo cache
-RUN cargo search
 
 RUN mkdir -p ~/.gnupg
 RUN echo "disable-ccid" > ~/.gnupg/scdaemon.conf


### PR DESCRIPTION
Required as trussed-staging now has a MSRV of 1.70.

For some reason it fails with

```
/app/.cache/cargo/bin/cargo-tarpaulin: error while loading shared libraries: libssl.so.1.1: cannot open shared object file: No such file or directory
```

But `lld` on the binary gets:

```
	linux-vdso.so.1 (0x00007fff8ff19000)
	libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007f6b07dfe000)
	libcurl.so.4 => /lib/x86_64-linux-gnu/libcurl.so.4 (0x00007f6b06f50000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f6b06f30000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f6b06e51000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f6b06c70000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f6b07e26000)
	libnghttp2.so.14 => /lib/x86_64-linux-gnu/libnghttp2.so.14 (0x00007f6b06c41000)
	libidn2.so.0 => /lib/x86_64-linux-gnu/libidn2.so.0 (0x00007f6b06c10000)
	librtmp.so.1 => /lib/x86_64-linux-gnu/librtmp.so.1 (0x00007f6b06bf1000)
	libssh2.so.1 => /lib/x86_64-linux-gnu/libssh2.so.1 (0x00007f6b06bb0000)
	libpsl.so.5 => /lib/x86_64-linux-gnu/libpsl.so.5 (0x00007f6b06b9c000)
	libssl.so.3 => /lib/x86_64-linux-gnu/libssl.so.3 (0x00007f6b06af2000)
	libcrypto.so.3 => /lib/x86_64-linux-gnu/libcrypto.so.3 (0x00007f6b06600000)
	libgssapi_krb5.so.2 => /lib/x86_64-linux-gnu/libgssapi_krb5.so.2 (0x00007f6b06aa0000)
	libldap-2.5.so.0 => /lib/x86_64-linux-gnu/libldap-2.5.so.0 (0x00007f6b065a1000)
	liblber-2.5.so.0 => /lib/x86_64-linux-gnu/liblber-2.5.so.0 (0x00007f6b06a90000)
	libzstd.so.1 => /lib/x86_64-linux-gnu/libzstd.so.1 (0x00007f6b064e5000)
	libbrotlidec.so.1 => /lib/x86_64-linux-gnu/libbrotlidec.so.1 (0x00007f6b06a83000)
	libunistring.so.2 => /lib/x86_64-linux-gnu/libunistring.so.2 (0x00007f6b0632f000)
	libgnutls.so.30 => /lib/x86_64-linux-gnu/libgnutls.so.30 (0x00007f6b06000000)
	libhogweed.so.6 => /lib/x86_64-linux-gnu/libhogweed.so.6 (0x00007f6b062e6000)
	libnettle.so.8 => /lib/x86_64-linux-gnu/libnettle.so.8 (0x00007f6b06298000)
	libgmp.so.10 => /lib/x86_64-linux-gnu/libgmp.so.10 (0x00007f6b05f7f000)
	libkrb5.so.3 => /lib/x86_64-linux-gnu/libkrb5.so.3 (0x00007f6b05ea5000)
	libk5crypto.so.3 => /lib/x86_64-linux-gnu/libk5crypto.so.3 (0x00007f6b0626b000)
	libcom_err.so.2 => /lib/x86_64-linux-gnu/libcom_err.so.2 (0x00007f6b06265000)
	libkrb5support.so.0 => /lib/x86_64-linux-gnu/libkrb5support.so.0 (0x00007f6b06257000)
	libsasl2.so.2 => /lib/x86_64-linux-gnu/libsasl2.so.2 (0x00007f6b0623a000)
	libbrotlicommon.so.1 => /lib/x86_64-linux-gnu/libbrotlicommon.so.1 (0x00007f6b05e82000)
	libp11-kit.so.0 => /lib/x86_64-linux-gnu/libp11-kit.so.0 (0x00007f6b05d4e000)
	libtasn1.so.6 => /lib/x86_64-linux-gnu/libtasn1.so.6 (0x00007f6b06225000)
	libkeyutils.so.1 => /lib/x86_64-linux-gnu/libkeyutils.so.1 (0x00007f6b0621e000)
	libresolv.so.2 => /lib/x86_64-linux-gnu/libresolv.so.2 (0x00007f6b05d3d000)
	libffi.so.8 => /lib/x86_64-linux-gnu/libffi.so.8 (0x00007f6b05d31000)
```

With only `libssl.so.3` so I don't see where the error comes from.