### PR TITLE
Make RSA key size support a runtime configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ admin-app = { version = "0.1.0", optional = true }
 apdu-dispatch = { version = "0.1", optional = true }
 delog = { version = "0.1.7", optional = true }
 vpicc = { version = "0.1.0", optional = true }
+cfg-if = "1.0.0"
 
 [dev-dependencies]
 env_logger = "0.9"

--- a/src/card.rs
+++ b/src/card.rs
@@ -167,7 +167,7 @@ pub enum RsaKeySizes {
 }
 
 impl RsaKeySizes {
-    fn default_gen() -> Self {
+    fn default_max_gen() -> Self {
         cfg_if! {
             if #[cfg(feature = "rsa4096-gen")] {
                 Self::Rsa4096
@@ -178,7 +178,7 @@ impl RsaKeySizes {
             }
         }
     }
-    fn default_import() -> Self {
+    fn default_max_import() -> Self {
         cfg_if! {
             if #[cfg(feature = "rsa4096")] {
                 Self::Rsa4096
@@ -210,10 +210,10 @@ pub struct Options {
     pub storage: Location,
 
     /// Max RSA size allowed to be imported
-    pub rsa_import: RsaKeySizes,
+    pub rsa_max_import: RsaKeySizes,
 
     /// Max RSA size allowed to be generated
-    pub rsa_gen: RsaKeySizes,
+    pub rsa_max_gen: RsaKeySizes,
 
     /// Flag to signal that the application has had its configuration changed or was factory-resetted by the admin application
     ///
@@ -258,8 +258,8 @@ impl Default for Options {
             historical_bytes: heapless::Vec::from_slice(&hex!("0031F573C00160009000")).unwrap(),
             button_available: true,
             storage: Location::External,
-            rsa_import: RsaKeySizes::default_import(),
-            rsa_gen: RsaKeySizes::default_gen(),
+            rsa_max_import: RsaKeySizes::default_max_import(),
+            rsa_max_gen: RsaKeySizes::default_max_gen(),
             #[cfg(feature = "admin-app")]
             reset_signal: None,
         }

--- a/src/card.rs
+++ b/src/card.rs
@@ -3,6 +3,7 @@
 
 #[cfg(feature = "admin-app")]
 use admin_app::{ResetSignal, ResetSignalAllocation};
+use cfg_if::cfg_if;
 use hex_literal::hex;
 use iso7816::Status;
 use trussed::types::Location;
@@ -158,6 +159,38 @@ impl<T: Client, const C: usize, const R: usize> apdu_dispatch::App<C, R> for Car
     }
 }
 
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+pub enum RsaKeySizes {
+    Rsa2048,
+    Rsa3072,
+    Rsa4096,
+}
+
+impl RsaKeySizes {
+    fn default_gen() -> Self {
+        cfg_if! {
+            if #[cfg(feature = "rsa4096-gen")] {
+                Self::Rsa4096
+            } else if #[cfg(feature = "rsa3072-gen")] {
+                Self::Rsa3072
+            } else {
+                Self::Rsa2048
+            }
+        }
+    }
+    fn default_import() -> Self {
+        cfg_if! {
+            if #[cfg(feature = "rsa4096")] {
+                Self::Rsa4096
+            } else if #[cfg(feature = "rsa3072")] {
+                Self::Rsa3072
+            } else {
+                Self::Rsa2048
+            }
+        }
+    }
+}
+
 /// Options for the OpenPGP card.
 #[derive(Clone, Debug)]
 #[non_exhaustive]
@@ -175,6 +208,12 @@ pub struct Options {
     pub button_available: bool,
     /// Which trussed storage to use
     pub storage: Location,
+
+    /// Max RSA size allowed to be imported
+    pub rsa_import: RsaKeySizes,
+
+    /// Max RSA size allowed to be generated
+    pub rsa_gen: RsaKeySizes,
 
     /// Flag to signal that the application has had its configuration changed or was factory-resetted by the admin application
     ///
@@ -219,6 +258,8 @@ impl Default for Options {
             historical_bytes: heapless::Vec::from_slice(&hex!("0031F573C00160009000")).unwrap(),
             button_available: true,
             storage: Location::External,
+            rsa_import: RsaKeySizes::default_import(),
+            rsa_gen: RsaKeySizes::default_gen(),
             #[cfg(feature = "admin-app")]
             reset_signal: None,
         }
@@ -300,6 +341,11 @@ mod tests {
             Options::default().aid(),
             hex!("D2 76 00 01 24 01 03 04 00 00 00 00 00 00 00 00"),
         )
+    }
+
+    #[test]
+    fn key_sizes() {
+        assert!(RsaKeySizes::Rsa2048 < RsaKeySizes::Rsa4096);
     }
 }
 

--- a/src/command/gen.rs
+++ b/src/command/gen.rs
@@ -37,7 +37,7 @@ pub fn sign<const R: usize, T: crate::card::Client>(
             gen_ec_key(ctx.lend(), KeyType::Sign, CurveAlgo::EcDsaP256)
         }
         SignatureAlgorithm::Rsa2048 => {
-            if ctx.options.rsa_gen >= RsaKeySizes::Rsa2048 {
+            if ctx.options.rsa_max_gen >= RsaKeySizes::Rsa2048 {
                 gen_rsa_key(ctx.lend(), KeyType::Sign, Mechanism::Rsa2048Pkcs1v15)
             } else {
                 warn!("Attempt to generate key disabled {:?}", algo);
@@ -45,7 +45,7 @@ pub fn sign<const R: usize, T: crate::card::Client>(
             }
         }
         SignatureAlgorithm::Rsa3072 => {
-            if ctx.options.rsa_gen >= RsaKeySizes::Rsa3072 {
+            if ctx.options.rsa_max_gen >= RsaKeySizes::Rsa3072 {
                 gen_rsa_key(ctx.lend(), KeyType::Sign, Mechanism::Rsa3072Pkcs1v15)
             } else {
                 warn!("Attempt to generate key disabled {:?}", algo);
@@ -53,7 +53,7 @@ pub fn sign<const R: usize, T: crate::card::Client>(
             }
         }
         SignatureAlgorithm::Rsa4096 => {
-            if ctx.options.rsa_gen >= RsaKeySizes::Rsa4096 {
+            if ctx.options.rsa_max_gen >= RsaKeySizes::Rsa4096 {
                 gen_rsa_key(ctx.lend(), KeyType::Sign, Mechanism::Rsa4096Pkcs1v15)
             } else {
                 warn!("Attempt to generate key disabled {:?}", algo);
@@ -72,7 +72,7 @@ pub fn dec<const R: usize, T: crate::card::Client>(
         DecryptionAlgorithm::X255 => gen_ec_key(ctx.lend(), KeyType::Dec, CurveAlgo::X255),
         DecryptionAlgorithm::EcDhP256 => gen_ec_key(ctx.lend(), KeyType::Dec, CurveAlgo::EcDhP256),
         DecryptionAlgorithm::Rsa2048 => {
-            if ctx.options.rsa_gen >= RsaKeySizes::Rsa2048 {
+            if ctx.options.rsa_max_gen >= RsaKeySizes::Rsa2048 {
                 gen_rsa_key(ctx.lend(), KeyType::Dec, Mechanism::Rsa2048Pkcs1v15)
             } else {
                 warn!("Attempt to generate key disabled {:?}", algo);
@@ -80,7 +80,7 @@ pub fn dec<const R: usize, T: crate::card::Client>(
             }
         }
         DecryptionAlgorithm::Rsa3072 => {
-            if ctx.options.rsa_gen >= RsaKeySizes::Rsa3072 {
+            if ctx.options.rsa_max_gen >= RsaKeySizes::Rsa3072 {
                 gen_rsa_key(ctx.lend(), KeyType::Dec, Mechanism::Rsa3072Pkcs1v15)
             } else {
                 warn!("Attempt to generate key disabled {:?}", algo);
@@ -88,7 +88,7 @@ pub fn dec<const R: usize, T: crate::card::Client>(
             }
         }
         DecryptionAlgorithm::Rsa4096 => {
-            if ctx.options.rsa_gen >= RsaKeySizes::Rsa4096 {
+            if ctx.options.rsa_max_gen >= RsaKeySizes::Rsa4096 {
                 gen_rsa_key(ctx.lend(), KeyType::Dec, Mechanism::Rsa4096Pkcs1v15)
             } else {
                 warn!("Attempt to generate key disabled {:?}", algo);
@@ -109,7 +109,7 @@ pub fn aut<const R: usize, T: crate::card::Client>(
             gen_ec_key(ctx.lend(), KeyType::Aut, CurveAlgo::EcDsaP256)
         }
         AuthenticationAlgorithm::Rsa2048 => {
-            if ctx.options.rsa_gen >= RsaKeySizes::Rsa2048 {
+            if ctx.options.rsa_max_gen >= RsaKeySizes::Rsa2048 {
                 gen_rsa_key(ctx.lend(), KeyType::Aut, Mechanism::Rsa2048Pkcs1v15)
             } else {
                 warn!("Attempt to generate key disabled {:?}", algo);
@@ -117,7 +117,7 @@ pub fn aut<const R: usize, T: crate::card::Client>(
             }
         }
         AuthenticationAlgorithm::Rsa3072 => {
-            if ctx.options.rsa_gen >= RsaKeySizes::Rsa3072 {
+            if ctx.options.rsa_max_gen >= RsaKeySizes::Rsa3072 {
                 gen_rsa_key(ctx.lend(), KeyType::Aut, Mechanism::Rsa3072Pkcs1v15)
             } else {
                 warn!("Attempt to generate key disabled {:?}", algo);
@@ -125,7 +125,7 @@ pub fn aut<const R: usize, T: crate::card::Client>(
             }
         }
         AuthenticationAlgorithm::Rsa4096 => {
-            if ctx.options.rsa_gen >= RsaKeySizes::Rsa4096 {
+            if ctx.options.rsa_max_gen >= RsaKeySizes::Rsa4096 {
                 gen_rsa_key(ctx.lend(), KeyType::Aut, Mechanism::Rsa4096Pkcs1v15)
             } else {
                 warn!("Attempt to generate key disabled {:?}", algo);

--- a/src/command/gen.rs
+++ b/src/command/gen.rs
@@ -6,7 +6,7 @@ use iso7816::Status;
 use trussed::try_syscall;
 use trussed::types::{KeyId, KeySerialization, Location, Mechanism, StorageAttributes};
 
-use crate::card::LoadedContext;
+use crate::card::{LoadedContext, RsaKeySizes};
 use crate::state::KeyOrigin;
 use crate::types::*;
 
@@ -37,28 +37,25 @@ pub fn sign<const R: usize, T: crate::card::Client>(
             gen_ec_key(ctx.lend(), KeyType::Sign, CurveAlgo::EcDsaP256)
         }
         SignatureAlgorithm::Rsa2048 => {
-            #[cfg(feature = "rsa2048-gen")]
-            return gen_rsa_key(ctx.lend(), KeyType::Sign, Mechanism::Rsa2048Pkcs1v15);
-            #[cfg(not(feature = "rsa2048-gen"))]
-            {
+            if ctx.options.rsa_gen >= RsaKeySizes::Rsa2048 {
+                gen_rsa_key(ctx.lend(), KeyType::Sign, Mechanism::Rsa2048Pkcs1v15)
+            } else {
                 warn!("Attempt to generate key disabled {:?}", algo);
                 Err(Status::FunctionNotSupported)
             }
         }
         SignatureAlgorithm::Rsa3072 => {
-            #[cfg(feature = "rsa3072-gen")]
-            return gen_rsa_key(ctx.lend(), KeyType::Sign, Mechanism::Rsa3072Pkcs1v15);
-            #[cfg(not(feature = "rsa3072-gen"))]
-            {
+            if ctx.options.rsa_gen >= RsaKeySizes::Rsa3072 {
+                gen_rsa_key(ctx.lend(), KeyType::Sign, Mechanism::Rsa3072Pkcs1v15)
+            } else {
                 warn!("Attempt to generate key disabled {:?}", algo);
                 Err(Status::FunctionNotSupported)
             }
         }
         SignatureAlgorithm::Rsa4096 => {
-            #[cfg(feature = "rsa4096-gen")]
-            return gen_rsa_key(ctx.lend(), KeyType::Sign, Mechanism::Rsa4096Pkcs1v15);
-            #[cfg(not(feature = "rsa4096-gen"))]
-            {
+            if ctx.options.rsa_gen >= RsaKeySizes::Rsa4096 {
+                gen_rsa_key(ctx.lend(), KeyType::Sign, Mechanism::Rsa4096Pkcs1v15)
+            } else {
                 warn!("Attempt to generate key disabled {:?}", algo);
                 Err(Status::FunctionNotSupported)
             }
@@ -75,28 +72,25 @@ pub fn dec<const R: usize, T: crate::card::Client>(
         DecryptionAlgorithm::X255 => gen_ec_key(ctx.lend(), KeyType::Dec, CurveAlgo::X255),
         DecryptionAlgorithm::EcDhP256 => gen_ec_key(ctx.lend(), KeyType::Dec, CurveAlgo::EcDhP256),
         DecryptionAlgorithm::Rsa2048 => {
-            #[cfg(feature = "rsa2048-gen")]
-            return gen_rsa_key(ctx.lend(), KeyType::Dec, Mechanism::Rsa2048Pkcs1v15);
-            #[cfg(not(feature = "rsa2048-gen"))]
-            {
+            if ctx.options.rsa_gen >= RsaKeySizes::Rsa2048 {
+                gen_rsa_key(ctx.lend(), KeyType::Dec, Mechanism::Rsa2048Pkcs1v15)
+            } else {
                 warn!("Attempt to generate key disabled {:?}", algo);
                 Err(Status::FunctionNotSupported)
             }
         }
         DecryptionAlgorithm::Rsa3072 => {
-            #[cfg(feature = "rsa3072-gen")]
-            return gen_rsa_key(ctx.lend(), KeyType::Dec, Mechanism::Rsa3072Pkcs1v15);
-            #[cfg(not(feature = "rsa3072-gen"))]
-            {
+            if ctx.options.rsa_gen >= RsaKeySizes::Rsa3072 {
+                gen_rsa_key(ctx.lend(), KeyType::Dec, Mechanism::Rsa3072Pkcs1v15)
+            } else {
                 warn!("Attempt to generate key disabled {:?}", algo);
                 Err(Status::FunctionNotSupported)
             }
         }
         DecryptionAlgorithm::Rsa4096 => {
-            #[cfg(feature = "rsa4096-gen")]
-            return gen_rsa_key(ctx.lend(), KeyType::Dec, Mechanism::Rsa4096Pkcs1v15);
-            #[cfg(not(feature = "rsa4096-gen"))]
-            {
+            if ctx.options.rsa_gen >= RsaKeySizes::Rsa4096 {
+                gen_rsa_key(ctx.lend(), KeyType::Dec, Mechanism::Rsa4096Pkcs1v15)
+            } else {
                 warn!("Attempt to generate key disabled {:?}", algo);
                 Err(Status::FunctionNotSupported)
             }
@@ -115,28 +109,25 @@ pub fn aut<const R: usize, T: crate::card::Client>(
             gen_ec_key(ctx.lend(), KeyType::Aut, CurveAlgo::EcDsaP256)
         }
         AuthenticationAlgorithm::Rsa2048 => {
-            #[cfg(feature = "rsa2048-gen")]
-            return gen_rsa_key(ctx.lend(), KeyType::Aut, Mechanism::Rsa2048Pkcs1v15);
-            #[cfg(not(feature = "rsa2048-gen"))]
-            {
+            if ctx.options.rsa_gen >= RsaKeySizes::Rsa2048 {
+                gen_rsa_key(ctx.lend(), KeyType::Aut, Mechanism::Rsa2048Pkcs1v15)
+            } else {
                 warn!("Attempt to generate key disabled {:?}", algo);
                 Err(Status::FunctionNotSupported)
             }
         }
         AuthenticationAlgorithm::Rsa3072 => {
-            #[cfg(feature = "rsa3072-gen")]
-            return gen_rsa_key(ctx.lend(), KeyType::Aut, Mechanism::Rsa3072Pkcs1v15);
-            #[cfg(not(feature = "rsa3072-gen"))]
-            {
+            if ctx.options.rsa_gen >= RsaKeySizes::Rsa3072 {
+                gen_rsa_key(ctx.lend(), KeyType::Aut, Mechanism::Rsa3072Pkcs1v15)
+            } else {
                 warn!("Attempt to generate key disabled {:?}", algo);
                 Err(Status::FunctionNotSupported)
             }
         }
         AuthenticationAlgorithm::Rsa4096 => {
-            #[cfg(feature = "rsa4096-gen")]
-            return gen_rsa_key(ctx.lend(), KeyType::Aut, Mechanism::Rsa4096Pkcs1v15);
-            #[cfg(not(feature = "rsa4096-gen"))]
-            {
+            if ctx.options.rsa_gen >= RsaKeySizes::Rsa4096 {
+                gen_rsa_key(ctx.lend(), KeyType::Aut, Mechanism::Rsa4096Pkcs1v15)
+            } else {
                 warn!("Attempt to generate key disabled {:?}", algo);
                 Err(Status::FunctionNotSupported)
             }
@@ -144,7 +135,7 @@ pub fn aut<const R: usize, T: crate::card::Client>(
     }
 }
 
-#[cfg(feature = "rsa2048-gen")]
+#[cfg(feature = "rsa")]
 fn gen_rsa_key<const R: usize, T: crate::card::Client>(
     mut ctx: LoadedContext<'_, R, T>,
     key: KeyType,
@@ -181,6 +172,14 @@ fn gen_rsa_key<const R: usize, T: crate::card::Client>(
         )
         .map_err(|_| Status::UnspecifiedNonpersistentExecutionError)?;
     read_rsa_key(ctx, pubkey, mechanism)
+}
+#[cfg(not(feature = "rsa"))]
+fn gen_rsa_key<const R: usize, T: crate::card::Client>(
+    _ctx: LoadedContext<'_, R, T>,
+    _key: KeyType,
+    _mechanism: Mechanism,
+) -> Result<(), Status> {
+    Err(Status::FunctionNotSupported)
 }
 
 fn gen_ec_key<const R: usize, T: crate::card::Client>(

--- a/src/command/private_key_template.rs
+++ b/src/command/private_key_template.rs
@@ -43,13 +43,13 @@ pub fn put_sign<const R: usize, T: crate::card::Client>(
     let key_id = match attr {
         SignatureAlgorithm::EcDsaP256 => put_ec(ctx.lend(), CurveAlgo::EcDsaP256)?,
         SignatureAlgorithm::Ed255 => put_ec(ctx.lend(), CurveAlgo::Ed255)?,
-        SignatureAlgorithm::Rsa2048 if ctx.options.rsa_import >= RsaKeySizes::Rsa2048 => {
+        SignatureAlgorithm::Rsa2048 if ctx.options.rsa_max_import >= RsaKeySizes::Rsa2048 => {
             put_rsa(ctx.lend(), Mechanism::Rsa2048Pkcs1v15)?
         }
-        SignatureAlgorithm::Rsa3072 if ctx.options.rsa_import >= RsaKeySizes::Rsa3072 => {
+        SignatureAlgorithm::Rsa3072 if ctx.options.rsa_max_import >= RsaKeySizes::Rsa3072 => {
             put_rsa(ctx.lend(), Mechanism::Rsa3072Pkcs1v15)?
         }
-        SignatureAlgorithm::Rsa4096 if ctx.options.rsa_import >= RsaKeySizes::Rsa4096 => {
+        SignatureAlgorithm::Rsa4096 if ctx.options.rsa_max_import >= RsaKeySizes::Rsa4096 => {
             put_rsa(ctx.lend(), Mechanism::Rsa4096Pkcs1v15)?
         }
         _ => {
@@ -79,13 +79,13 @@ pub fn put_dec<const R: usize, T: crate::card::Client>(
     let key_id = match attr {
         DecryptionAlgorithm::EcDhP256 => put_ec(ctx.lend(), CurveAlgo::EcDhP256)?,
         DecryptionAlgorithm::X255 => put_ec(ctx.lend(), CurveAlgo::X255)?,
-        DecryptionAlgorithm::Rsa2048 if ctx.options.rsa_import >= RsaKeySizes::Rsa2048 => {
+        DecryptionAlgorithm::Rsa2048 if ctx.options.rsa_max_import >= RsaKeySizes::Rsa2048 => {
             put_rsa(ctx.lend(), Mechanism::Rsa2048Pkcs1v15)?
         }
-        DecryptionAlgorithm::Rsa3072 if ctx.options.rsa_import >= RsaKeySizes::Rsa3072 => {
+        DecryptionAlgorithm::Rsa3072 if ctx.options.rsa_max_import >= RsaKeySizes::Rsa3072 => {
             put_rsa(ctx.lend(), Mechanism::Rsa3072Pkcs1v15)?
         }
-        DecryptionAlgorithm::Rsa4096 if ctx.options.rsa_import >= RsaKeySizes::Rsa4096 => {
+        DecryptionAlgorithm::Rsa4096 if ctx.options.rsa_max_import >= RsaKeySizes::Rsa4096 => {
             put_rsa(ctx.lend(), Mechanism::Rsa4096Pkcs1v15)?
         }
         _ => {
@@ -115,13 +115,13 @@ pub fn put_aut<const R: usize, T: crate::card::Client>(
     let key_id = match attr {
         AuthenticationAlgorithm::EcDsaP256 => put_ec(ctx.lend(), CurveAlgo::EcDsaP256)?,
         AuthenticationAlgorithm::Ed255 => put_ec(ctx.lend(), CurveAlgo::Ed255)?,
-        AuthenticationAlgorithm::Rsa2048 if ctx.options.rsa_import >= RsaKeySizes::Rsa2048 => {
+        AuthenticationAlgorithm::Rsa2048 if ctx.options.rsa_max_import >= RsaKeySizes::Rsa2048 => {
             put_rsa(ctx.lend(), Mechanism::Rsa2048Pkcs1v15)?
         }
-        AuthenticationAlgorithm::Rsa3072 if ctx.options.rsa_import >= RsaKeySizes::Rsa3072 => {
+        AuthenticationAlgorithm::Rsa3072 if ctx.options.rsa_max_import >= RsaKeySizes::Rsa3072 => {
             put_rsa(ctx.lend(), Mechanism::Rsa3072Pkcs1v15)?
         }
-        AuthenticationAlgorithm::Rsa4096 if ctx.options.rsa_import >= RsaKeySizes::Rsa4096 => {
+        AuthenticationAlgorithm::Rsa4096 if ctx.options.rsa_max_import >= RsaKeySizes::Rsa4096 => {
             put_rsa(ctx.lend(), Mechanism::Rsa4096Pkcs1v15)?
         }
         _ => {

--- a/src/command/private_key_template.rs
+++ b/src/command/private_key_template.rs
@@ -5,7 +5,7 @@ use iso7816::Status;
 use trussed::try_syscall;
 use trussed::types::{KeyId, KeySerialization, Location, Mechanism, StorageAttributes};
 
-use crate::card::LoadedContext;
+use crate::card::{LoadedContext, RsaKeySizes};
 use crate::state::KeyOrigin;
 use crate::tlv::get_do;
 use crate::types::*;
@@ -43,9 +43,19 @@ pub fn put_sign<const R: usize, T: crate::card::Client>(
     let key_id = match attr {
         SignatureAlgorithm::EcDsaP256 => put_ec(ctx.lend(), CurveAlgo::EcDsaP256)?,
         SignatureAlgorithm::Ed255 => put_ec(ctx.lend(), CurveAlgo::Ed255)?,
-        SignatureAlgorithm::Rsa2048 => put_rsa(ctx.lend(), Mechanism::Rsa2048Pkcs1v15)?,
-        SignatureAlgorithm::Rsa3072 => put_rsa(ctx.lend(), Mechanism::Rsa3072Pkcs1v15)?,
-        SignatureAlgorithm::Rsa4096 => put_rsa(ctx.lend(), Mechanism::Rsa4096Pkcs1v15)?,
+        SignatureAlgorithm::Rsa2048 if ctx.options.rsa_import >= RsaKeySizes::Rsa2048 => {
+            put_rsa(ctx.lend(), Mechanism::Rsa2048Pkcs1v15)?
+        }
+        SignatureAlgorithm::Rsa3072 if ctx.options.rsa_import >= RsaKeySizes::Rsa3072 => {
+            put_rsa(ctx.lend(), Mechanism::Rsa3072Pkcs1v15)?
+        }
+        SignatureAlgorithm::Rsa4096 if ctx.options.rsa_import >= RsaKeySizes::Rsa4096 => {
+            put_rsa(ctx.lend(), Mechanism::Rsa4096Pkcs1v15)?
+        }
+        _ => {
+            warn!("Attempt to import key disabled {:?}", attr);
+            return Err(Status::FunctionNotSupported);
+        }
     }
     .map(|(private_key, pubkey)| (private_key, (pubkey, KeyOrigin::Imported)));
     ctx.state
@@ -69,9 +79,19 @@ pub fn put_dec<const R: usize, T: crate::card::Client>(
     let key_id = match attr {
         DecryptionAlgorithm::EcDhP256 => put_ec(ctx.lend(), CurveAlgo::EcDhP256)?,
         DecryptionAlgorithm::X255 => put_ec(ctx.lend(), CurveAlgo::X255)?,
-        DecryptionAlgorithm::Rsa2048 => put_rsa(ctx.lend(), Mechanism::Rsa2048Pkcs1v15)?,
-        DecryptionAlgorithm::Rsa3072 => put_rsa(ctx.lend(), Mechanism::Rsa3072Pkcs1v15)?,
-        DecryptionAlgorithm::Rsa4096 => put_rsa(ctx.lend(), Mechanism::Rsa4096Pkcs1v15)?,
+        DecryptionAlgorithm::Rsa2048 if ctx.options.rsa_import >= RsaKeySizes::Rsa2048 => {
+            put_rsa(ctx.lend(), Mechanism::Rsa2048Pkcs1v15)?
+        }
+        DecryptionAlgorithm::Rsa3072 if ctx.options.rsa_import >= RsaKeySizes::Rsa3072 => {
+            put_rsa(ctx.lend(), Mechanism::Rsa3072Pkcs1v15)?
+        }
+        DecryptionAlgorithm::Rsa4096 if ctx.options.rsa_import >= RsaKeySizes::Rsa4096 => {
+            put_rsa(ctx.lend(), Mechanism::Rsa4096Pkcs1v15)?
+        }
+        _ => {
+            warn!("Attempt to import key disabled {:?}", attr);
+            return Err(Status::FunctionNotSupported);
+        }
     }
     .map(|(private_key, pubkey)| (private_key, (pubkey, KeyOrigin::Imported)));
     ctx.state
@@ -95,9 +115,19 @@ pub fn put_aut<const R: usize, T: crate::card::Client>(
     let key_id = match attr {
         AuthenticationAlgorithm::EcDsaP256 => put_ec(ctx.lend(), CurveAlgo::EcDsaP256)?,
         AuthenticationAlgorithm::Ed255 => put_ec(ctx.lend(), CurveAlgo::Ed255)?,
-        AuthenticationAlgorithm::Rsa2048 => put_rsa(ctx.lend(), Mechanism::Rsa2048Pkcs1v15)?,
-        AuthenticationAlgorithm::Rsa3072 => put_rsa(ctx.lend(), Mechanism::Rsa3072Pkcs1v15)?,
-        AuthenticationAlgorithm::Rsa4096 => put_rsa(ctx.lend(), Mechanism::Rsa4096Pkcs1v15)?,
+        AuthenticationAlgorithm::Rsa2048 if ctx.options.rsa_import >= RsaKeySizes::Rsa2048 => {
+            put_rsa(ctx.lend(), Mechanism::Rsa2048Pkcs1v15)?
+        }
+        AuthenticationAlgorithm::Rsa3072 if ctx.options.rsa_import >= RsaKeySizes::Rsa3072 => {
+            put_rsa(ctx.lend(), Mechanism::Rsa3072Pkcs1v15)?
+        }
+        AuthenticationAlgorithm::Rsa4096 if ctx.options.rsa_import >= RsaKeySizes::Rsa4096 => {
+            put_rsa(ctx.lend(), Mechanism::Rsa4096Pkcs1v15)?
+        }
+        _ => {
+            warn!("Attempt to import key disabled {:?}", attr);
+            return Err(Status::FunctionNotSupported);
+        }
     }
     .map(|(private_key, public_key)| (private_key, (public_key, KeyOrigin::Imported)));
     ctx.state


### PR DESCRIPTION
This will enable us to allow RSA 4096 bit key generation when the se050 backend is enabled.