### PR TITLE
Use extension crates instead of trussed-staging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ SPDX-License-Identifier: CC0-1.0
 
 # Changelog
 
+## Unreleased
+
+- Use `trussed-chunked` and `trussed-wrap-key-to-file` instead of
+  `trussed-staging`, see [trussed-staging#19][].
+
+[trussed-staging#19]: https://github.com/trussed-dev/trussed-staging/pull/19
 
 ## [v1.3.0][] (2023-12-01)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,9 @@ log = "0.4"
 serde = { version = "1.0", default-features = false }
 subtle = { version = "2.4.1", default-features = false }
 trussed = "0.1.0"
+trussed-chunked = "0.1.0"
 trussed-rsa-alloc = { version = "0.1.0", optional = true }
-trussed-staging = { version = "0.1.0", features = ["wrap-key-to-file", "chunked", "encrypted-chunked"]}
+trussed-wrap-key-to-file = "0.1.0"
 serde_repr = "0.1"
 hex-literal = "0.4.1"
 trussed-auth = "0.2.1"
@@ -41,6 +42,7 @@ admin-app = { version = "0.1.0", optional = true }
 # optional dependencies
 apdu-dispatch = { version = "0.1", optional = true }
 delog = { version = "0.1.7", optional = true }
+trussed-staging = { version = "0.2.0", features = ["chunked", "wrap-key-to-file"], optional = true }
 vpicc = { version = "0.1.0", optional = true }
 cfg-if = "1.0.0"
 
@@ -68,7 +70,7 @@ trussed-usbip = { version = "0.0.1", default-features = false, features = ["ccid
 default = []
 std = []
 vpicc = ["std", "dep:vpicc", "virt"]
-virt = ["std", "trussed/virt"]
+virt = ["std", "trussed/virt", "trussed-staging"]
 
 rsa = ["trussed-rsa-alloc"]
 rsa2048 = ["rsa"]
@@ -94,12 +96,15 @@ littlefs2 = { git = "https://github.com/trussed-dev/littlefs2.git", rev = "ebd27
 p256-cortex-m4 = { git = "https://github.com/Nitrokey/p256-cortex-m4", tag = "v0.1.0-alpha.6-nitrokey-1" }
 trussed = { git = "https://github.com/Nitrokey/trussed" , tag = "v0.1.0-nitrokey.18" }
 trussed-auth = { git = "https://github.com/trussed-dev/trussed-auth.git", rev = "4b8191f248c26cb074cdac887c7f3f48f9c449a4"}
+trussed-chunked = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "chunked-v0.1.0" }
+trussed-manage = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "manage-v0.1.0" }
 trussed-rsa-alloc = { git = "https://github.com/trussed-dev/trussed-rsa-backend.git", rev = "9732a9a3e98af72112286afdc9b7174c66c2869a" }
-trussed-staging = { git = "https://github.com/Nitrokey/trussed-staging.git", tag = "v0.1.0-nitrokey-hmac256p256.3" }
+trussed-staging = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "v0.2.0" }
+trussed-wrap-key-to-file = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "wrap-key-to-file-v0.1.0" }
 apdu-dispatch = { git = "https://github.com/Nitrokey/apdu-dispatch", tag = "v0.1.2-nitrokey.2" }
 trussed-usbip = { git = "https://github.com/Nitrokey/pc-usbip-runner.git", tag = "v0.0.1-nitrokey.1" }
 usbd-ccid = { git = "https://github.com/Nitrokey/usbd-ccid", tag = "v0.2.0-nitrokey.1" }
-admin-app = { git = "https://github.com/Nitrokey/admin-app.git", rev = "410899311ae7b194360366ff477f74d4d278e056" }
+admin-app = { git = "https://github.com/Nitrokey/admin-app.git", tag = "v0.1.0-nitrokey.11" }
 ctaphid-dispatch = { git = "https://github.com/trussed-dev/ctaphid-dispatch.git", rev = "57cb3317878a8593847595319aa03ef17c29ec5b" }
 
 [package.metadata.docs.rs]

--- a/src/card.rs
+++ b/src/card.rs
@@ -8,7 +8,7 @@ use hex_literal::hex;
 use iso7816::Status;
 use trussed::types::Location;
 use trussed_auth::AuthClient;
-use trussed_staging::streaming::ChunkedClient;
+use trussed_chunked::ChunkedClient;
 
 pub(crate) mod reply;
 
@@ -356,7 +356,7 @@ mod tests {
     }
 }
 
-use trussed_staging::wrap_key_to_file::WrapKeyToFileClient;
+use trussed_wrap_key_to_file::WrapKeyToFileClient;
 
 /// Super trait with all trussed extensions required by opcard
 pub trait Client: trussed::Client + AuthClient + WrapKeyToFileClient + ChunkedClient {}

--- a/src/state.rs
+++ b/src/state.rs
@@ -13,7 +13,7 @@ use trussed::api::reply::Metadata;
 use trussed::config::MAX_MESSAGE_LENGTH;
 use trussed::types::{KeyId, Location, Mechanism, PathBuf, StorageAttributes};
 use trussed::{syscall, try_syscall};
-use trussed_staging::streaming::utils::{write_all, EncryptionData};
+use trussed_chunked::utils::{write_all, EncryptionData};
 
 use crate::card::reply::Reply;
 use crate::command::{Password, PasswordMode};

--- a/src/virt.rs
+++ b/src/virt.rs
@@ -16,10 +16,9 @@ pub mod dispatch {
         types::{Bytes, Context, Location},
     };
     use trussed_auth::{AuthBackend, AuthContext, AuthExtension, MAX_HW_KEY_LEN};
-    use trussed_staging::{
-        streaming::ChunkedExtension, wrap_key_to_file::WrapKeyToFileExtension, StagingBackend,
-        StagingContext,
-    };
+    use trussed_chunked::ChunkedExtension;
+    use trussed_staging::{StagingBackend, StagingContext};
+    use trussed_wrap_key_to_file::WrapKeyToFileExtension;
 
     #[cfg(feature = "rsa")]
     use trussed_rsa_alloc::SoftwareRsa;


### PR DESCRIPTION
This patch adapts to the extraction of extension crates from trussed-staging, see:
        https://github.com/trussed-dev/trussed-staging/pull/19