### PR TITLE
Fix response when using an unconfigured key for an operation

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -562,6 +562,11 @@ impl<'a> LoadedState<'a> {
     ) -> Result<KeyId, Status> {
         use KeyType as K;
         use UserVerifiedInner as V;
+
+        if self.persistent.public_key_id(key).is_none() {
+            return Err(Status::KeyReferenceNotFound);
+        }
+
         // Self::limit_cache_size is there to avoid having multiple keys in the volatile storage.
         // RSA keys can be up 2.3KB out of the total 8KiB.
         // With 3 keys this gets us very close to being full, especially with the added overhead of littlefs metadata

--- a/tests/command-response.ron
+++ b/tests/command-response.ron
@@ -208,4 +208,21 @@
             GetLargeData(tag: CardHolderCertificate, start: 1, len: 2058, occurence: First),
         ]
     ),
+    IoTest(
+        name: "Key not found"  ,
+        cmd_resp: [
+            Verify(pin: Pw1),
+            Sign(
+                expected_status: KeyReferenceNotFound,
+            ),
+            Verify(pin: Pw82),
+            Decrypt(
+                key_kind: Rsa2048,
+                expected_status: KeyReferenceNotFound,
+            ),
+            Authenticate(
+                expected_status: KeyReferenceNotFound,
+            ),
+        ],
+    ),
 ]


### PR DESCRIPTION
Fix https://github.com/Nitrokey/opcard-rs/issues/205

This PR adds test for the correct status being returned for operations when no key is present.