### PR TITLE
Use &Path instead of &str for constant paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ required-features = ["apdu-dispatch"]
 heapless = "0.7"
 heapless-bytes = "0.3"
 iso7816 = "0.1.3"
+littlefs2 = "0.4"
 log = "0.4"
 serde = { version = "1.0", default-features = false }
 subtle = { version = "2.4.1", default-features = false }

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,7 +4,7 @@
 use hex_literal::hex;
 use iso7816::Status;
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use trussed::types::Mechanism;
+use trussed::types::{Mechanism, Path};
 
 use crate::card::AllowedAlgorithms;
 use crate::error::Error;
@@ -498,7 +498,7 @@ impl KeyType {
         }
     }
 
-    pub fn path(&self) -> &'static str {
+    pub fn path(&self) -> &'static Path {
         match self {
             KeyType::Sign => crate::state::SIGNING_KEY_PATH,
             KeyType::Aut => crate::state::AUTH_KEY_PATH,


### PR DESCRIPTION
This is already slightly more efficient and will be especially important once the string/path conversions in littlefs2 become fallible.