### PR TITLE
Update changelog and cargo manifest for v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ SPDX-License-Identifier: CC0-1.0
 
 ## Unreleased
 
+## [v1.5.0][] (2024-07-31)
+
+[v1.5.0]: https://github.com/Nitrokey/opcard-rs/releases/tag/v1.5.0
+
+- Add support for more curves ([#207][]):
+  - secp384r1 (NIST P-384)
+  - secp521r1 (NIST P-521)
+  - brainpoolp256r1
+  - brainpoolp384r1
+  - brainpoolp512r1
+
+[#207]: https://github.com/Nitrokey/opcard-rs/pull/207
+
 ## [v1.4.1][] (2024-03-22)
 
 [v1.4.1]: https://github.com/Nitrokey/opcard-rs/releases/tag/v1.4.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "opcard"
-version = "1.4.1"
+version = "1.5.0"
 authors = ["Nitrokey GmbH <info@nitrokey.com>"]
 edition = "2021"
 description = "OpenPGP smart card implementation"


### PR DESCRIPTION
[v1.5.0](https://github.com/Nitrokey/opcard-rs/releases/tag/v1.5.0) was already tagged but not added to the changelog or cargo manifest.