### PR TITLE
Fix CI errors with Rust 1.84

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ dangerous-test-real-card = []
 # used for delog
 log-all = []
 log-none = []
+log-trace = []
 log-info = []
 log-debug = []
 log-warn = []

--- a/src/card.rs
+++ b/src/card.rs
@@ -313,7 +313,7 @@ pub struct Context<'a, const R: usize, T: Client> {
     pub reply: Reply<'a, R>,
 }
 
-impl<'a, const R: usize, T: Client> Context<'a, R, T> {
+impl<const R: usize, T: Client> Context<'_, R, T> {
     pub fn load_state(&mut self) -> Result<LoadedContext<'_, R, T>, Status> {
         Ok(LoadedContext {
             state: self
@@ -352,7 +352,7 @@ pub struct LoadedContext<'a, const R: usize, T: Client> {
     pub reply: Reply<'a, R>,
 }
 
-impl<'a, const R: usize, T: Client> LoadedContext<'a, R, T> {
+impl<const R: usize, T: Client> LoadedContext<'_, R, T> {
     /// Lend the context
     ///
     /// The resulting `LoadedContext` has a shorter lifetime than the original one, meaning that it

--- a/src/card/reply.rs
+++ b/src/card/reply.rs
@@ -15,13 +15,13 @@ impl<'v, const R: usize> Deref for Reply<'v, R> {
     }
 }
 
-impl<'v, const R: usize> DerefMut for Reply<'v, R> {
+impl<const R: usize> DerefMut for Reply<'_, R> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
-impl<'v, const R: usize> Reply<'v, R> {
+impl<const R: usize> Reply<'_, R> {
     /// Extend the reply and return an error otherwise
     /// The MoreAvailable and GET RESPONSE mechanisms are handled by adpu_dispatch
     ///

--- a/src/state.rs
+++ b/src/state.rs
@@ -241,7 +241,7 @@ pub struct LoadedState<'s> {
     pub volatile: &'s mut Volatile,
 }
 
-impl<'a> LoadedState<'a> {
+impl LoadedState<'_> {
     /// Lend the state
     ///
     /// The resulting `LoadedState` has a shorter lifetime than the original one, meaning that it

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -33,7 +33,7 @@ pub mod serde_bytes {
 
     struct ArrayVisitor<const N: usize>;
 
-    impl<'de, const N: usize> Visitor<'de> for ArrayVisitor<N> {
+    impl<const N: usize> Visitor<'_> for ArrayVisitor<N> {
         type Value = [u8; N];
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
             write!(formatter, "An array of bytes")

--- a/tests/gpg/mod.rs
+++ b/tests/gpg/mod.rs
@@ -551,7 +551,7 @@ const DEFAULT_PW1: &str = "123456";
 struct FileDropper<'s> {
     temp_file_name: &'s str,
 }
-impl<'s> Drop for FileDropper<'s> {
+impl Drop for FileDropper<'_> {
     fn drop(&mut self) {
         std::fs::remove_file(self.temp_file_name).ok();
     }


### PR DESCRIPTION
This patch fixes some issues causing CI failure after updating the image from Rust 1.80 to 1.84 to fix a dependency with an increased MSRV.