### PR TITLE
Replace trussed-rsa-alloc dependency with trussed-rsa-types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ SPDX-License-Identifier: CC0-1.0
 
 ## Unreleased
 
--
+- Replace `trussed-rsa-alloc` dependency with `trussed-rsa-types` for most use cases.
+  (Only the `virt` feature still requires `trussed-rsa-alloc`.)
 
 ## [v1.6.1][] (2025-07-31)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ trussed-chunked = "0.2.0"
 # TODO: only set RSA features if RSA is enabled?
 trussed-core = { version = "0.1.0-rc.1", features = ["aes256-cbc", "brainpoolp256r1", "brainpoolp384r1", "brainpoolp512r1", "chacha8-poly1305", "crypto-client", "ed255", "filesystem-client", "p256", "p384", "p521", "rsa2048", "rsa3072", "rsa4096", "secp256k1", "shared-secret", "ui-client", "x255"] }
 trussed-rsa-alloc = { version = "0.3.0", optional = true }
+trussed-rsa-types = { version = "0.1", optional = true }
 trussed-wrap-key-to-file = "0.2.0"
 serde_repr = "0.1"
 hex-literal = "0.4.1"
@@ -79,9 +80,9 @@ default = []
 std = []
 apdu-dispatch = ["dep:apdu-app"]
 vpicc = ["std", "dep:vpicc", "virt"]
-virt = ["std", "trussed/virt", "trussed-auth-backend", "trussed-staging"]
+virt = ["std", "trussed/virt", "trussed-auth-backend", "trussed-rsa-alloc", "trussed-staging"]
 
-rsa = ["trussed-rsa-alloc"]
+rsa = ["trussed-rsa-types"]
 rsa2048 = ["rsa"]
 rsa2048-gen = ["rsa2048"]
 rsa3072 = ["rsa2048"]

--- a/src/command/gen.rs
+++ b/src/command/gen.rs
@@ -13,7 +13,7 @@ use crate::types::*;
 const KEYGEN_DO_TAG: &[u8] = &hex!("7f49");
 
 #[cfg(feature = "rsa")]
-use trussed_rsa_alloc::RsaPublicParts;
+use trussed_rsa_types::RsaPublicParts;
 
 fn serialize_pub<const R: usize, T: crate::card::Client>(
     algo: CurveAlgo,

--- a/src/command/private_key_template.rs
+++ b/src/command/private_key_template.rs
@@ -15,7 +15,7 @@ const CARDHOLDER_PRIVATE_KEY_TEMPLATE_DO: u16 = 0x7F48;
 const CONCATENATION_KEY_DATA_DO: u16 = 0x5F48;
 
 #[cfg(feature = "rsa")]
-use trussed_rsa_alloc::RsaImportFormat;
+use trussed_rsa_types::RsaImportFormat;
 
 // § 4.4.3.12
 pub fn put_private_key_template<const R: usize, T: crate::card::Client>(


### PR DESCRIPTION
trussed-rsa-alloc is only required if both the rsa and the virt feature are enabled.  We cannot express this currently, but always pulling it in for the virt feature should be fine too.